### PR TITLE
NEX-1194: Port upstream full_size_button flag for per-fixture start button size

### DIFF
--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -43,6 +43,7 @@ class FrontendConfig(BaseModel):
     port: int = 8000
     language: str = "en"
     url: str = "localhost"
+    full_size_button: bool = True
 
 
 class StandCloudConfig(BaseModel):

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -472,6 +472,8 @@ function App(): JSX.Element {
     return <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>{tags}</div>;
   };
 
+  const useBigButton = hardpyConfig?.frontend?.full_size_button !== false;
+
   return (
     <div className="App">
       <ReloadAlert reload_timeout_s={3} />
@@ -568,20 +570,90 @@ function App(): JSX.Element {
         {renderNavStatusTags()}
       </div>
 
-      {/* Tests panel */}
-      <div className={Classes.DRAWER_BODY} style={{ marginBottom: "140px" }}>
+      {/* Main content area with test suites and results */}
+      <div
+        className={Classes.DRAWER_BODY}
+        style={{
+          marginBottom: "60px",
+          paddingBottom: useBigButton ? "120px" : "80px",
+        }}
+      >
         {renderDbContent()}
       </div>
 
-      {/* Footer */}
-
-      <div className={`${Classes.DRAWER_FOOTER} hardpy-footer`}>
-        <div className="hardpy-footer-progress">
-          <ProgressView percentage={lastProgress} status={lastRunStatus} />
-        </div>
-        <div className="hardpy-footer-button">
-          <StartStopButton testing_status={lastRunStatus} />
-        </div>
+      {/* Footer with progress bar and control buttons */}
+      <div
+        className={Classes.DRAWER_FOOTER}
+        style={{
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          position: "fixed",
+          bottom: 0,
+          background: Colors.LIGHT_GRAY5,
+          margin: "auto",
+        }}
+      >
+        {useBigButton ? (
+          <>
+            <div
+              style={{
+                width: "100%",
+                padding: "10px 20px 0px 20px",
+              }}
+            >
+              <ProgressView
+                percentage={lastProgress}
+                status={lastRunStatus}
+              />
+            </div>
+            <div
+              style={{
+                width: "100%",
+                padding: "10px 20px",
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
+              <div style={{ width: "100%" }}>
+                <StartStopButton
+                  testing_status={lastRunStatus}
+                  useBigButton={true}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "row",
+            }}
+          >
+            <div
+              style={{
+                flexDirection: "column",
+                flexGrow: 1,
+                flexShrink: 1,
+                marginTop: "auto",
+                marginBottom: "auto",
+                padding: "20px",
+              }}
+            >
+              <ProgressView
+                percentage={lastProgress}
+                status={lastRunStatus}
+              />
+            </div>
+            <div style={{ flexDirection: "column" }}>
+              <StartStopButton
+                testing_status={lastRunStatus}
+                useBigButton={false}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Test Config Selection Overlay */}

--- a/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
+++ b/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
@@ -4,17 +4,27 @@
 import * as React from "react";
 import { AnchorButton, AnchorButtonProps } from "@blueprintjs/core";
 import { withTranslation, WithTranslation } from "react-i18next";
-import { isDialogOpen } from '../dialogueUtils';
 
-type Props = { testing_status: string } & WithTranslation;
+type Props = {
+  testing_status: string;
+  useBigButton?: boolean;
+  manualCollectMode?: boolean;
+  onTestRunStart?: () => void;
+} & WithTranslation;
 
 type State = {
   isStopButtonDisabled: boolean;
 };
 
+// Global variables for ModalResult state
+declare let isCompletionModalResultVisible: boolean;
+declare let lastModalResultDismissTime: number;
+declare const MODAL_RESULT_DISMISS_COOLDOWN: number;
+
 /**
  * A React component that renders a start/stop button for controlling a testing process.
  * The button's behavior and appearance depend on the testing status.
+ * Handles space key events for keyboard control and prevents actions during modal display.
  */
 class StartStopButton extends React.Component<Props, State> {
   private stopButtonTimer: NodeJS.Timeout | null = null;
@@ -24,6 +34,7 @@ class StartStopButton extends React.Component<Props, State> {
     this.state = {
       isStopButtonDisabled: false,
     };
+
     this.hardpy_start = this.hardpy_start.bind(this);
     this.hardpy_stop = this.hardpy_stop.bind(this);
   }
@@ -33,20 +44,12 @@ class StartStopButton extends React.Component<Props, State> {
    * @param {string} uri - The URI to which the fetch request is made.
    * @private
    */
-  private hardpy_call(uri: string) {
-    fetch(uri)
-      .then((response) => {
-        if (response.ok) {
-          return response.text();
-        } else {
-          console.log(
-            this.props.t("error.requestFailed", { status: response.status })
-          );
-        }
-      })
-      .catch((error) => {
-        console.log(this.props.t("error.requestError", { error }));
-      });
+  private hardpy_call(uri: string): void {
+    fetch(uri).then((response) => {
+      if (response.ok) {
+        return response.text();
+      }
+    });
   }
 
   /**
@@ -54,62 +57,188 @@ class StartStopButton extends React.Component<Props, State> {
    * @private
    */
   private hardpy_start(): void {
+    if (this.props.manualCollectMode) {
+      return;
+    }
+
+    if (this.props.onTestRunStart) {
+      this.props.onTestRunStart();
+    }
+
     this.hardpy_call("api/start");
   }
 
   /**
    * Initiates the stop process by making a call to the 'api/stop' endpoint.
+   * Temporarily disables the stop button to prevent multiple rapid clicks.
    * @private
    */
   private hardpy_stop(): void {
+    if (this.props.manualCollectMode) {
+      return;
+    }
+
     if (this.state.isStopButtonDisabled) {
       return;
     }
     this.hardpy_call("api/stop");
 
-    // Disable the stop button for some time
+    // Disable the stop button for some time to prevent multiple rapid clicks
     this.setState({ isStopButtonDisabled: true });
     this.stopButtonTimer = setTimeout(() => {
       this.setState({ isStopButtonDisabled: false });
     }, 500);
   }
+  /**
+   * Checks if any dialog is currently open in the application.
+   * Searches for both Blueprint.js dialogs and standard ARIA dialogs.
+   * @returns {boolean} True if a dialog is open and visible, false otherwise.
+   */
+  private isDialogOpen(): boolean {
+    const blueprintDialogs = document.querySelectorAll(".bp3-dialog");
+    for (const dialog of blueprintDialogs) {
+      const style = window.getComputedStyle(dialog);
+      if (style.display !== "none" && style.visibility !== "hidden") {
+        return true;
+      }
+    }
+
+    const ariaDialogs = document.querySelectorAll('[role="dialog"]');
+    for (const dialog of ariaDialogs) {
+      const style = window.getComputedStyle(dialog);
+      if (style.display !== "none" && style.visibility !== "hidden") {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   /**
-   * Handles the space keydown event to start or stop the process.
+   * Checks if the completion ModalResult is currently visible.
+   * First attempts to use the global variable, falls back to DOM inspection.
+   * @returns {boolean} True if the completion ModalResult is visible, false otherwise.
    */
-  private readonly handleSpaceKey = (event: KeyboardEvent) => {
-    if (isDialogOpen()) {
+  private isCompletionModalResultVisible(): boolean {
+    try {
+      if (typeof isCompletionModalResultVisible !== "undefined") {
+        return isCompletionModalResultVisible;
+      }
+    } catch (error) {
+      console.warn(
+        "StartStopButton: Could not access global ModalResult visibility variable"
+      );
+    }
+
+    // Fallback: check if ModalResult element exists in DOM by z-index
+    const ModalResultElements = document.querySelectorAll(
+      '[style*="z-index: 9999"]'
+    );
+    return ModalResultElements.length > 0;
+  }
+
+  /**
+   * Checks if the application is in the cooldown period after ModalResult dismissal.
+   * Prevents immediate space key actions after the ModalResult is dismissed.
+   * @returns {boolean} True if within the cooldown period, false otherwise.
+   */
+  private isInModalResultDismissCooldown(): boolean {
+    try {
+      if (
+        typeof lastModalResultDismissTime !== "undefined" &&
+        typeof MODAL_RESULT_DISMISS_COOLDOWN !== "undefined"
+      ) {
+        const now = Date.now();
+        return now - lastModalResultDismissTime < MODAL_RESULT_DISMISS_COOLDOWN;
+      }
+    } catch (error) {
+      console.warn("StartStopButton: Could not access cooldown variables");
+    }
+    return false;
+  }
+
+  /**
+   * Handles the space keydown event to start or stop the testing process.
+   * Prevents space key actions when ModalResult is visible or during cooldown period.
+   * Also prevents action when dialogs are open or interactive elements are focused.
+   * @param {KeyboardEvent} event - The keyboard event object
+   */
+  private readonly handleSpaceKey = (event: KeyboardEvent): void => {
+    // Only handle Space key, let other keys pass through
+    if (event.key !== " ") {
+      return;
+    }
+
+    if (this.props.manualCollectMode) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    // Check if completion ModalResult is visible
+    if (this.isCompletionModalResultVisible()) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    // Check if we're in cooldown period after ModalResult dismissal
+    if (this.isInModalResultDismissCooldown()) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    // Don't handle space if any dialog is open
+    if (this.isDialogOpen()) {
       return;
     }
 
     const target = event.target as HTMLElement;
-    if (!target) return;
+    if (!target) {
+      return;
+    }
 
-    const interactiveElements = ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'];
+    // Don't handle space if focused on interactive elements
+    const interactiveElements = ["INPUT", "TEXTAREA", "SELECT", "BUTTON"];
     if (
-      interactiveElements.includes(target.tagName) || 
+      interactiveElements.includes(target.tagName) ||
       target.isContentEditable
     ) {
       return;
     }
 
-    if (event.key === " ") {
-      event.preventDefault();
-      const is_testing_in_progress = this.props.testing_status == "run";
-      is_testing_in_progress ? this.hardpy_stop() : this.hardpy_start();
-    }
+    event.preventDefault();
+    const is_testing_in_progress = this.props.testing_status == "run";
+    is_testing_in_progress ? this.hardpy_stop() : this.hardpy_start();
   };
 
   /**
-   * Handles the button click event to start the process.
+   * Handles the button click event to start the testing process.
+   * Prevents button clicks when ModalResult is visible or during cooldown period.
    * @private
    */
   private readonly handleButtonClick = (): void => {
+    if (this.props.manualCollectMode) {
+      return;
+    }
+
+    // Check if completion ModalResult is visible
+    if (this.isCompletionModalResultVisible()) {
+      return;
+    }
+
+    // Check if we're in cooldown period after ModalResult dismissal
+    if (this.isInModalResultDismissCooldown()) {
+      return;
+    }
+
     this.hardpy_start();
   };
 
   /**
    * Adds an event listener for the keydown event when the component is mounted.
+   * Uses bubbling phase to not interfere with other capture phase listeners.
    */
   componentDidMount(): void {
     window.addEventListener("keydown", this.handleSpaceKey);
@@ -117,6 +246,7 @@ class StartStopButton extends React.Component<Props, State> {
 
   /**
    * Removes the event listener for the keydown event when the component is unmounted.
+   * Also clears any pending timers to prevent memory leaks.
    */
   componentWillUnmount(): void {
     window.removeEventListener("keydown", this.handleSpaceKey);
@@ -127,37 +257,81 @@ class StartStopButton extends React.Component<Props, State> {
 
   /**
    * Renders the Start/Stop button with appropriate properties based on the testing status.
+   * Shows stop button when testing is in progress, start button otherwise.
    * @returns {React.ReactNode} The Start/Stop button component.
    */
   render(): React.ReactNode {
-    const { t, testing_status } = this.props;
+    const {
+      t,
+      testing_status,
+      useBigButton = false,
+      manualCollectMode = false,
+    } = this.props;
     const is_testing: boolean = testing_status == "run";
     const button_id: string = "start-stop-button";
 
-    const stop_button: AnchorButtonProps = {
-      text: t("button.stop"),
-      intent: "danger",
-      large: true,
-      rightIcon: "stop",
-      onClick: this.hardpy_stop,
-      id: button_id,
-      fill: true,
-      style: { width: "100%", height: "96px", fontSize: "16px" },
-    };
+    if (useBigButton) {
+      const bigButtonStyle = {
+        width: "100%",
+        height: "96px",
+        fontSize: "24px",
+        fontWeight: "bold",
+        opacity: manualCollectMode ? 0.5 : 1,
+      };
 
-    const start_button: AnchorButtonProps = {
-      text: t("button.start"),
-      intent: is_testing ? undefined : "primary",
-      large: true,
-      rightIcon: "play",
-      onClick: this.handleButtonClick,
-      id: button_id,
-      disabled: this.state.isStopButtonDisabled,
-      fill: true,
-      style: { width: "100%", height: "96px", fontSize: "16px" },
-    };
+      const iconStyle = {
+        fontSize: "28px",
+        marginLeft: "12px",
+      };
 
-    return <AnchorButton {...(is_testing ? stop_button : start_button)} />;
+      const stop_button: AnchorButtonProps = {
+        text: t("button.stop"),
+        intent: "danger",
+        large: true,
+        rightIcon: <span style={iconStyle}>&#9632;</span>,
+        onClick: this.hardpy_stop,
+        id: button_id,
+        fill: true,
+        style: bigButtonStyle,
+        disabled: manualCollectMode || this.state.isStopButtonDisabled,
+      };
+
+      const start_button: AnchorButtonProps = {
+        text: t("button.start"),
+        intent: is_testing ? undefined : "primary",
+        large: true,
+        rightIcon: <span style={iconStyle}>&#9658;</span>,
+        onClick: this.handleButtonClick,
+        id: button_id,
+        disabled: manualCollectMode || this.state.isStopButtonDisabled,
+        fill: true,
+        style: bigButtonStyle,
+      };
+
+      return <AnchorButton {...(is_testing ? stop_button : start_button)} />;
+    } else {
+      const stop_button: AnchorButtonProps = {
+        text: t("button.stop"),
+        intent: "danger",
+        large: true,
+        rightIcon: "stop",
+        onClick: this.hardpy_stop,
+        id: button_id,
+        disabled: manualCollectMode || this.state.isStopButtonDisabled,
+      };
+
+      const start_button: AnchorButtonProps = {
+        text: t("button.start"),
+        intent: is_testing ? undefined : "primary",
+        large: true,
+        rightIcon: "play",
+        onClick: this.handleButtonClick,
+        id: button_id,
+        disabled: manualCollectMode || this.state.isStopButtonDisabled,
+      };
+
+      return <AnchorButton {...(is_testing ? stop_button : start_button)} />;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `[frontend].full_size_button` config flag (default `true`) so fixtures can pick big-button vs stock Blueprint button via `hardpy.toml` instead of CSS.
- Replaces `StartStop.tsx` byte-for-byte with `upstream/main`'s version — zero divergence to manage on the next upstream sync.
- Restores the pinned-footer layout (regression from a prior refactor that referenced `.hardpy-footer` CSS rules that were never added). Uses upstream's inline-style footer block verbatim.

Parent ticket: [NEX-1173](https://tovala.atlassian.net/browse/NEX-1173)
Fixes: [NEX-1194](https://tovala.atlassian.net/browse/NEX-1194)

## Why

`hellraiser` and `midline` fixtures need different start-button sizes. Today the button hardcodes `width/height/fontSize` inline, so any per-fixture variation needed `!important` CSS — which is what landed `feature/css-customization` in circles. Upstream solved this with a config flag instead. Porting that approach keeps us aligned with upstream.

## Files

- `hardpy/common/config.py` — `+1` (`full_size_button: bool = True`)
- `hardpy/hardpy_panel/frontend/src/button/StartStop.tsx` — replaced verbatim with upstream
- `hardpy/hardpy_panel/frontend/src/App.tsx` — `useBigButton` prop wiring + restored upstream's pinned-footer block

## Test plan

- [x] `vite build` succeeds.
- [x] TypeScript check shows only the 4 pre-existing errors elsewhere; nothing new in this change.
- [x] Local verification with CouchDB + backend + Vite dev across the network (browser on a different host than the service via Tailscale).
- [x] Default config (no `full_size_button` in toml) → big button (96px tall, 24px bold, unicode glyphs).
- [x] `full_size_button = false` under `[frontend]` → stock Blueprint button (smaller, `play`/`stop` Blueprint icons).
- [x] Footer stays pinned to the viewport bottom in both layouts; body content scrolls behind it.
- [ ] Verified on hellraiser fixture (separate ticket — fixture toml updates land in `~/code/hardpy-appliance`).
- [ ] Verified on midline fixture (separate ticket).

## Out of scope

- Applying the flag in fixture-specific `hardpy.toml` files in `~/code/hardpy-appliance`. Tracked separately once this lands.
- Pulling the rest of upstream v0.19.1.
- Four follow-up panel UX items (assert rendering readability, long-string wrap, autoscroll/autoexpand jitter, arrow-key nav crash). Will be filed under NEX-1173 after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NEX-1173]: https://tovala.atlassian.net/browse/NEX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1194]: https://tovala.atlassian.net/browse/NEX-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ