### PR TITLE
NEX-1202: Wrap long strings in operator panel tags

### DIFF
--- a/examples/long_strings/database/couchdb.ini
+++ b/examples/long_strings/database/couchdb.ini
@@ -1,0 +1,109 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[couchdb]
+;max_document_size = 4294967296 ; bytes
+;os_process_timeout = 5000
+
+[couch_peruser]
+; If enabled, couch_peruser ensures that a private per-user database
+; exists for each document in _users. These databases are writable only
+; by the corresponding user. Databases are in the following form:
+; userdb-{hex encoded username}
+;enable = true
+
+; If set to true and a user is deleted, the respective database gets
+; deleted as well.
+;delete_dbs = true
+
+; Set a default q value for peruser-created databases that is different from
+; cluster / q
+;q = 1
+
+[chttpd]
+;port = 5984
+;bind_address = localhost
+
+; Options for the MochiWeb HTTP server.
+;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
+
+; For more socket options, consult Erlang's module 'inet' man page.
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+
+enable_cors=true
+
+[httpd]
+; NOTE that this only configures the "backend" node-local port, not the
+; "frontend" clustered port. You probably don't want to change anything in
+; this section.
+; Uncomment next line to trigger basic-auth popup on unauthorized requests.
+;WWW-Authenticate = Basic realm="administrator"
+
+; Uncomment next line to set the configuration modification whitelist. Only
+; whitelisted values may be changed via the /_config URLs. To allow the admin
+; to change this value over HTTP, remember to include {httpd,config_whitelist}
+; itself. Excluding it from the list would require editing this file to update
+; the whitelist.
+;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
+
+[cors]
+origins = *
+methods = GET, PUT, POST, HEAD, DELETE
+credentials = true
+headers = accept, authorization, content-type, origin, referer, x-csrf-token
+
+
+[ssl]
+;enable = true
+;cert_file = /full/path/to/server_cert.pem
+;key_file = /full/path/to/server_key.pem
+;password = somepassword
+
+; set to true to validate peer certificates
+;verify_ssl_certificates = false
+
+; Set to true to fail if the client does not send a certificate. Only used if verify_ssl_certificates is true.
+;fail_if_no_peer_cert = false
+
+; Path to file containing PEM encoded CA certificates (trusted
+; certificates used for verifying a peer certificate). May be omitted if
+; you do not want to verify the peer.
+;cacert_file = /full/path/to/cacertf
+
+; The verification fun (optional) if not specified, the default
+; verification fun will be used.
+;verify_fun = {Module, VerifyFun}
+
+; maximum peer certificate depth
+;ssl_certificate_max_depth = 1
+
+; Reject renegotiations that do not live up to RFC 5746.
+;secure_renegotiate = true
+
+; The cipher suites that should be supported.
+; Can be specified in erlang format "{ecdhe_ecdsa,aes_128_cbc,sha256}"
+; or in OpenSSL format "ECDHE-ECDSA-AES128-SHA256".
+;ciphers = ["ECDHE-ECDSA-AES128-SHA256", "ECDHE-ECDSA-AES128-SHA"]
+
+; The SSL/TLS versions to support
+;tls_versions = [tlsv1, 'tlsv1.1', 'tlsv1.2']
+
+; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
+; the Virtual Host will be redirected to the path. In the example below all requests
+; to http://example.com/ are redirected to /database.
+; If you run CouchDB on a specific port, include the port number in the vhost:
+; example.com:5984 = /database
+[vhosts]
+;example.com = /database/
+
+; To create an admin account uncomment the '[admins]' section below and add a
+; line in the format 'username = password'. When you next start CouchDB, it
+; will change the password to a hash (so that your passwords don't linger
+; around in plain-text files). You can add more admin accounts with more
+; 'username = password' lines. Don't forget to restart CouchDB after
+; changing this.
+[admins]
+;admin = mysecretpassword

--- a/examples/long_strings/docker-compose.yaml
+++ b/examples/long_strings/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  couchserver:
+    image: couchdb:3.4
+    ports:
+      - "5984:5984"
+    environment:
+      COUCHDB_USER: dev
+      COUCHDB_PASSWORD: dev
+    volumes:
+      - ./database/dbdata:/opt/couchdb/data
+      - ./database/couchdb.ini:/opt/couchdb/etc/local.ini

--- a/examples/long_strings/hardpy.toml
+++ b/examples/long_strings/hardpy.toml
@@ -1,0 +1,21 @@
+title = "HardPy TOML config"
+tests_name = "Long Strings Demo"
+sound_on = false
+enable_test_pass_fail_modal = false
+
+[database]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[database_frontend]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[frontend]
+host = "localhost"
+port = 8000
+language = "en"

--- a/examples/long_strings/pytest.ini
+++ b/examples/long_strings/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --hardpy-pt
+          --hardpy-db-url http://dev:dev@localhost:5984/

--- a/examples/long_strings/test_long_strings.py
+++ b/examples/long_strings/test_long_strings.py
@@ -1,0 +1,103 @@
+"""Regression demo for NEX-1202: long strings in results / messages overflow the panel.
+
+Each test emits content that historically blew past the right edge of the operator
+panel without wrapping. Run via `hardpy run` from this directory and inspect the
+operator panel UI; long content should wrap cleanly inside the panel, not force
+horizontal scroll.
+"""
+
+import pytest
+
+from hardpy import (
+    ComparisonOperation as CompOp,
+    NumericMeasurement,
+    set_case_artifact,
+    set_case_measurement,
+    set_dut_info,
+    set_message,
+    set_stand_info,
+)
+
+pytestmark = pytest.mark.module_name("Long Strings")
+
+
+@pytest.mark.case_name("Long measurement name and value")
+def test_long_measurement():
+    long_name = "Very long descriptive measurement name that goes on for a while and probably exceeds typical column width on a 1080p operator display"
+    meas = NumericMeasurement(value=12345.6789, name=long_name, unit="mV")
+    set_case_measurement(meas)
+
+
+@pytest.mark.case_name("Measurement with long unbreakable string value")
+def test_unbreakable_string_value():
+    # SHA256-style hex: no spaces or hyphens, won't break unless we explicitly wrap it
+    sha_value = "a" + "1234567890abcdef" * 8
+    set_message(f"Computed hash: {sha_value}")
+
+
+@pytest.mark.case_name("Long single-line message")
+def test_long_message():
+    set_message(
+        "This is a long single-line operator message that contains many words "
+        "and should wrap naturally at word boundaries, but only if the rendering "
+        "component lets it. Otherwise it just stretches the panel to the right."
+    )
+
+
+@pytest.mark.case_name("Long message with no spaces")
+def test_long_message_no_spaces():
+    # The classic test: a single 200-char token (e.g. a path or URL with no breaks)
+    set_message("/very/long/filesystem/path/with/no/spaces/in/the/middle/which/typescript/components/tend/to/render/without/word-break/css/and/then/overflow/their/parent/container.txt")
+
+
+@pytest.mark.case_name("Multi-line message")
+def test_multiline_message():
+    set_message(
+        "Line one of a multi-line message.\n"
+        "Line two — should render as a separate visual line, not joined.\n"
+        "Line three with some context about the failure mode."
+    )
+
+
+@pytest.mark.case_name("Long assertion message")
+def test_long_assertion():
+    expected = 42
+    actual = 41
+    assert actual == expected, (
+        f"Expected value to be {expected} but got {actual}. "
+        "This assertion message is long on purpose so we can see how it renders "
+        "in the operator panel's fail window. Operators should be able to read "
+        "the whole message without scrolling horizontally, and ideally without "
+        "the traceback context drowning the actionable part."
+    )
+
+
+@pytest.mark.case_name("Long DUT and stand info")
+def test_long_info():
+    set_dut_info(
+        {
+            "serial_number": "VERYLONGSERIALNUMBER-1234567890-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "firmware_version": "1.2.3-rc4+build.20260512.commit.abc123def456",
+            "description": (
+                "A long descriptive blurb about this DUT that includes its full "
+                "model designation, build date, calibration history reference, "
+                "and any other context the operator might want."
+            ),
+        }
+    )
+    set_stand_info(
+        {
+            "fixture_id": "HELLRAISER-PROD-MANUFACTURING-LINE-3-STATION-7",
+            "location": "Building 4 / North Floor / Cell C-12 (the one near the loading dock)",
+        }
+    )
+
+
+@pytest.mark.case_name("Long artifact")
+def test_long_artifact():
+    set_case_artifact(
+        {
+            "raw_capture": "x" * 400,
+            "notes": "An artifact with a single 400-character unbroken string of x's. Renders the worst-case wrapping scenario.",
+        }
+    )

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -463,7 +463,7 @@ function App(): JSX.Element {
       }
 
       return (
-        <Tag key={key} minimal>
+        <Tag key={key} minimal multiline>
           {statusName}: {statusValue}
         </Tag>
       );

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
@@ -168,22 +168,22 @@ export class SuiteList extends React.Component<Props, State> {
         <div>
           <H1>{this.props.currentTestConfig || db_state.name}</H1>
           {db_state.test_stand && (
-            <Tag minimal style={TAG_ELEMENT_STYLE}>
+            <Tag minimal multiline style={TAG_ELEMENT_STYLE}>
               {t("suiteList.standName")}: {db_state.test_stand?.name}
             </Tag>
           )}
           {start && (
-            <Tag minimal style={TAG_ELEMENT_STYLE}>
+            <Tag minimal multiline style={TAG_ELEMENT_STYLE}>
               {t("suiteList.startTime")}: {start + start_tz}
             </Tag>
           )}
           {stop && (
-            <Tag minimal style={TAG_ELEMENT_STYLE}>
+            <Tag minimal multiline style={TAG_ELEMENT_STYLE}>
               {t("suiteList.finishTime")}: {stop + start_tz}
             </Tag>
           )}
           {alert && (
-            <Tag minimal style={TAG_ELEMENT_STYLE}>
+            <Tag minimal multiline style={TAG_ELEMENT_STYLE}>
               {t("suiteList.alert")}: {alert}
             </Tag>
           )}
@@ -192,7 +192,7 @@ export class SuiteList extends React.Component<Props, State> {
               <div style={{ display: "flex", flexWrap: "wrap", gap: "5px" }}>
                 {Object.entries(db_state.test_stand.info).map(
                   ([key, value]) => (
-                    <Tag key={key} minimal style={TAG_ELEMENT_STYLE}>
+                    <Tag key={key} minimal multiline style={TAG_ELEMENT_STYLE}>
                       {db_state.test_stand?.name} {key}:{" "}
                       {typeof value === "string"
                         ? value

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestData.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestData.tsx
@@ -25,7 +25,7 @@ interface Props {
   measurements?: Measurement[];
 }
 
-const TAG_ELEMENT_STYLE = { margin: 2 };
+const TAG_ELEMENT_STYLE = { margin: 2, whiteSpace: "pre-wrap" as const };
 
 /**
  * Renders a list of messages, measurements, and an assertion message as styled tags.
@@ -92,6 +92,7 @@ export function TestData(props: Readonly<Props>): React.ReactElement {
             key={`measurement-${index}`}
             style={TAG_ELEMENT_STYLE}
             minimal={true}
+            multiline={true}
             intent={intent}
           >
             {formatMeasurement(measurement, index)}
@@ -107,6 +108,7 @@ export function TestData(props: Readonly<Props>): React.ReactElement {
               key={key}
               style={TAG_ELEMENT_STYLE}
               minimal={true}
+              multiline={true}
               intent="primary"
             >
               {value}
@@ -121,6 +123,7 @@ export function TestData(props: Readonly<Props>): React.ReactElement {
           key={"assertion"}
           style={TAG_ELEMENT_STYLE}
           minimal={true}
+          multiline={true}
           intent="warning"
         >
           {props.assertion_msg.split("\n")[0]}


### PR DESCRIPTION
## Summary

Blueprint `<Tag>` components default to ellipsize (single-line, no wrap), so long measurement values / messages / asserts / stand info / nav status tags blew past the right edge of the operator panel and forced horizontal scroll. Upstream has the same bug — no fix to port.

Smallest-divergence approach using Blueprint's native `multiline` prop, plus a `whiteSpace: "pre-wrap"` shim so embedded `\n` in messages render as actual line breaks.

Fixes: [NEX-1202](https://tovala.atlassian.net/browse/NEX-1202)
Parent: [NEX-1173](https://tovala.atlassian.net/browse/NEX-1173)

## Changes

- `TestData.tsx` — `multiline={true}` on measurement / message / assertion tags. `TAG_ELEMENT_STYLE` extended with `whiteSpace: "pre-wrap"` so `\n` renders as a real line break (multiline alone uses `white-space: normal` which collapses newlines).
- `SuiteList.tsx` — `multiline` on the five tags (stand name, start time, finish time, alert, info key/value).
- `App.tsx` — `multiline` on the nav-status tag.
- `examples/long_strings/` — new demo with 8 test cases (long measurement values, SHA-style unbreakable strings, long single-line messages, no-space path-style strings, multi-line messages, long assertion messages, long DUT/stand info, long artifacts). Visual-regression coverage.

The static-content index tag in `TestSuite.tsx` (`minWidth: 15px`) is intentionally left as ellipsize — short content, no wrap needed.

## Test plan

- [x] `yarn build` succeeds.
- [x] TypeScript check shows only the 4 pre-existing errors elsewhere; nothing new in changed files.
- [x] Local verification: ran all 8 demo tests in the operator panel across a Tailscale-reachable host. All long strings wrap cleanly within the panel. Multi-line messages render with real line breaks. Long unbreakable strings (SHA-style, path-style) break mid-string without horizontal overflow.
- [ ] Verified on hellraiser / midline / endline fixtures (handled in NEX-1201 once a hardpy release ships).

## Out of scope

- Assert message readability — only first line shown today via `.split("\n")[0]` in `TestData.tsx`. That's [NEX-1190](https://tovala.atlassian.net/browse/NEX-1190).
- Other components (`DialogBox.tsx`, `OperatorMsg.tsx`) already have inline `wordWrap`/`wordBreak` — they render fine, not touched.
- Automating the `examples/long_strings/` demo in CI — it's a visual-regression check for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NEX-1202]: https://tovala.atlassian.net/browse/NEX-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1173]: https://tovala.atlassian.net/browse/NEX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1190]: https://tovala.atlassian.net/browse/NEX-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ