### PR TITLE
NEX-1203: Fix operator-panel autoscroll/autoexpand jitter + add auto_scroll config

### DIFF
--- a/examples/jitter_demo/database/couchdb.ini
+++ b/examples/jitter_demo/database/couchdb.ini
@@ -1,0 +1,109 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[couchdb]
+;max_document_size = 4294967296 ; bytes
+;os_process_timeout = 5000
+
+[couch_peruser]
+; If enabled, couch_peruser ensures that a private per-user database
+; exists for each document in _users. These databases are writable only
+; by the corresponding user. Databases are in the following form:
+; userdb-{hex encoded username}
+;enable = true
+
+; If set to true and a user is deleted, the respective database gets
+; deleted as well.
+;delete_dbs = true
+
+; Set a default q value for peruser-created databases that is different from
+; cluster / q
+;q = 1
+
+[chttpd]
+;port = 5984
+;bind_address = localhost
+
+; Options for the MochiWeb HTTP server.
+;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
+
+; For more socket options, consult Erlang's module 'inet' man page.
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+
+enable_cors=true
+
+[httpd]
+; NOTE that this only configures the "backend" node-local port, not the
+; "frontend" clustered port. You probably don't want to change anything in
+; this section.
+; Uncomment next line to trigger basic-auth popup on unauthorized requests.
+;WWW-Authenticate = Basic realm="administrator"
+
+; Uncomment next line to set the configuration modification whitelist. Only
+; whitelisted values may be changed via the /_config URLs. To allow the admin
+; to change this value over HTTP, remember to include {httpd,config_whitelist}
+; itself. Excluding it from the list would require editing this file to update
+; the whitelist.
+;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
+
+[cors]
+origins = *
+methods = GET, PUT, POST, HEAD, DELETE
+credentials = true
+headers = accept, authorization, content-type, origin, referer, x-csrf-token
+
+
+[ssl]
+;enable = true
+;cert_file = /full/path/to/server_cert.pem
+;key_file = /full/path/to/server_key.pem
+;password = somepassword
+
+; set to true to validate peer certificates
+;verify_ssl_certificates = false
+
+; Set to true to fail if the client does not send a certificate. Only used if verify_ssl_certificates is true.
+;fail_if_no_peer_cert = false
+
+; Path to file containing PEM encoded CA certificates (trusted
+; certificates used for verifying a peer certificate). May be omitted if
+; you do not want to verify the peer.
+;cacert_file = /full/path/to/cacertf
+
+; The verification fun (optional) if not specified, the default
+; verification fun will be used.
+;verify_fun = {Module, VerifyFun}
+
+; maximum peer certificate depth
+;ssl_certificate_max_depth = 1
+
+; Reject renegotiations that do not live up to RFC 5746.
+;secure_renegotiate = true
+
+; The cipher suites that should be supported.
+; Can be specified in erlang format "{ecdhe_ecdsa,aes_128_cbc,sha256}"
+; or in OpenSSL format "ECDHE-ECDSA-AES128-SHA256".
+;ciphers = ["ECDHE-ECDSA-AES128-SHA256", "ECDHE-ECDSA-AES128-SHA"]
+
+; The SSL/TLS versions to support
+;tls_versions = [tlsv1, 'tlsv1.1', 'tlsv1.2']
+
+; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
+; the Virtual Host will be redirected to the path. In the example below all requests
+; to http://example.com/ are redirected to /database.
+; If you run CouchDB on a specific port, include the port number in the vhost:
+; example.com:5984 = /database
+[vhosts]
+;example.com = /database/
+
+; To create an admin account uncomment the '[admins]' section below and add a
+; line in the format 'username = password'. When you next start CouchDB, it
+; will change the password to a hash (so that your passwords don't linger
+; around in plain-text files). You can add more admin accounts with more
+; 'username = password' lines. Don't forget to restart CouchDB after
+; changing this.
+[admins]
+;admin = mysecretpassword

--- a/examples/jitter_demo/docker-compose.yaml
+++ b/examples/jitter_demo/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  couchserver:
+    image: couchdb:3.4
+    ports:
+      - "5984:5984"
+    environment:
+      COUCHDB_USER: dev
+      COUCHDB_PASSWORD: dev
+    volumes:
+      - ./database/dbdata:/opt/couchdb/data
+      - ./database/couchdb.ini:/opt/couchdb/etc/local.ini

--- a/examples/jitter_demo/hardpy.toml
+++ b/examples/jitter_demo/hardpy.toml
@@ -1,0 +1,21 @@
+title = "HardPy TOML config"
+tests_name = "Autoscroll Jitter Demo"
+sound_on = false
+enable_test_pass_fail_modal = false
+
+[database]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[database_frontend]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[frontend]
+host = "localhost"
+port = 8000
+language = "en"

--- a/examples/jitter_demo/pytest.ini
+++ b/examples/jitter_demo/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --hardpy-pt
+          --hardpy-db-url http://dev:dev@localhost:5984/

--- a/examples/jitter_demo/test_1_setup.py
+++ b/examples/jitter_demo/test_1_setup.py
@@ -1,0 +1,26 @@
+"""Setup module — slow (~2s/case), all-pass. Lets the operator scroll freely."""
+
+import time
+import pytest
+
+from hardpy import set_message
+
+pytestmark = pytest.mark.module_name("Setup")
+
+
+@pytest.mark.case_name("Power on")
+def test_setup_power_on():
+    time.sleep(2.0)
+    set_message("Power supply nominal: 5.00V")
+
+
+@pytest.mark.case_name("Communication check")
+def test_setup_comm():
+    time.sleep(2.0)
+    set_message("Serial comms established at 115200 baud")
+
+
+@pytest.mark.case_name("Firmware version")
+def test_setup_fw():
+    time.sleep(2.0)
+    set_message("Firmware: 1.2.3-build.20260512")

--- a/examples/jitter_demo/test_2_smoke.py
+++ b/examples/jitter_demo/test_2_smoke.py
@@ -1,0 +1,51 @@
+"""Smoke module — fast burst (~0.15s/case). 8 cases in ~1.2s.
+
+Stresses scroll debounce + user-scroll-suppression: runningIndex changes ~6x/s.
+"""
+
+import time
+import pytest
+
+pytestmark = pytest.mark.module_name("Smoke")
+
+QUICK = 0.15
+
+
+@pytest.mark.case_name("GPIO readout 1")
+def test_smoke_1():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 2")
+def test_smoke_2():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 3")
+def test_smoke_3():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 4")
+def test_smoke_4():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 5")
+def test_smoke_5():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 6")
+def test_smoke_6():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 7")
+def test_smoke_7():
+    time.sleep(QUICK)
+
+
+@pytest.mark.case_name("GPIO readout 8")
+def test_smoke_8():
+    time.sleep(QUICK)

--- a/examples/jitter_demo/test_3_burst.py
+++ b/examples/jitter_demo/test_3_burst.py
@@ -1,0 +1,31 @@
+"""Burst module — one test case that streams 42 measurements at 0.5s intervals.
+
+runningIndex stays put for ~21s; only the row's content grows. Verifies that we
+don't repeatedly scroll while data flows into a stable row.
+"""
+
+import time
+import pytest
+
+from hardpy import (
+    ComparisonOperation as CompOp,
+    NumericMeasurement,
+    set_case_measurement,
+)
+
+pytestmark = pytest.mark.module_name("Burst")
+
+
+@pytest.mark.case_name("Stream 42 measurements (0.5s interval)")
+def test_burst_measurements():
+    for i in range(42):
+        meas = NumericMeasurement(
+            value=24.0 + 0.05 * i,
+            name=f"Sample {i + 1:02d}",
+            unit="C",
+            operation=CompOp.LE,
+            comparison_value=60.0,
+            disp=True,
+        )
+        set_case_measurement(meas)
+        time.sleep(0.5)

--- a/examples/jitter_demo/test_4_measurements.py
+++ b/examples/jitter_demo/test_4_measurements.py
@@ -1,0 +1,52 @@
+"""Measurements module — slow with a mid-run failure (triggers auto-expand)."""
+
+import time
+import pytest
+
+from hardpy import (
+    ComparisonOperation as CompOp,
+    NumericMeasurement,
+    set_case_measurement,
+)
+
+pytestmark = pytest.mark.module_name("Measurements")
+
+
+@pytest.mark.case_name("Voltage rail 3V3")
+def test_meas_3v3():
+    time.sleep(2.0)
+    meas = NumericMeasurement(
+        value=3.31, unit="V", operation=CompOp.GELE, lower_limit=3.20, upper_limit=3.40, disp=True
+    )
+    set_case_measurement(meas)
+    assert meas.result
+
+
+@pytest.mark.case_name("Voltage rail 5V0")
+def test_meas_5v0():
+    time.sleep(2.0)
+    meas = NumericMeasurement(
+        value=5.02, unit="V", operation=CompOp.GELE, lower_limit=4.90, upper_limit=5.10, disp=True
+    )
+    set_case_measurement(meas)
+    assert meas.result
+
+
+@pytest.mark.case_name("Voltage rail 12V (fails)")
+def test_meas_12v_fail():
+    time.sleep(2.0)
+    meas = NumericMeasurement(
+        value=10.8, unit="V", operation=CompOp.GELE, lower_limit=11.5, upper_limit=12.5, disp=True
+    )
+    set_case_measurement(meas)
+    assert meas.result, "12V rail out of spec — supply or load issue"
+
+
+@pytest.mark.case_name("Current draw")
+def test_meas_current():
+    time.sleep(2.0)
+    meas = NumericMeasurement(
+        value=0.42, unit="A", operation=CompOp.LE, comparison_value=1.0, disp=True
+    )
+    set_case_measurement(meas)
+    assert meas.result

--- a/examples/jitter_demo/test_5_functional.py
+++ b/examples/jitter_demo/test_5_functional.py
@@ -1,0 +1,37 @@
+"""Functional module — slow with a late failure.
+
+Operator's likely scrolled back to inspect earlier modules by now; this checks
+that the late-run auto-expand + auto-scroll behaves sanely (single animation,
+no yank if user is at near-bottom watching live).
+"""
+
+import time
+import pytest
+
+from hardpy import set_message
+
+pytestmark = pytest.mark.module_name("Functional")
+
+
+@pytest.mark.case_name("Boot sequence")
+def test_func_boot():
+    time.sleep(2.0)
+    set_message("Device reached operational state in 2.4s")
+
+
+@pytest.mark.case_name("LED indicators")
+def test_func_leds():
+    time.sleep(2.0)
+    set_message("All LEDs cycled green / amber / red as expected")
+
+
+@pytest.mark.case_name("Button response (fails)")
+def test_func_button_fail():
+    time.sleep(2.0)
+    assert False, "Button SW2 did not register press within 500ms"
+
+
+@pytest.mark.case_name("Final teardown")
+def test_func_teardown():
+    time.sleep(2.0)
+    set_message("All resources released, device powered down")

--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -44,6 +44,7 @@ class FrontendConfig(BaseModel):
     language: str = "en"
     url: str = "localhost"
     full_size_button: bool = True
+    auto_scroll: bool = True
 
 
 class StandCloudConfig(BaseModel):

--- a/hardpy/hardpy_panel/frontend/src/App.css
+++ b/hardpy/hardpy_panel/frontend/src/App.css
@@ -24,6 +24,18 @@ html {
   height: inherit;
 }
 
+/* scroll-padding accounts for the fixed Navbar at top and the fixed footer
+ * at bottom so that scrollIntoView() doesn't park a row behind either of them.
+ * The bottom value covers the big-button footer (~146px) with margin; the
+ * small-button footer is shorter so the row lands slightly higher than ideal,
+ * which is harmless.
+ */
+html,
+.bp5-drawer-body {
+  scroll-padding-top: 60px;
+  scroll-padding-bottom: 160px;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -371,6 +371,7 @@ function App(): JSX.Element {
                   db_state={row.doc as TestRunI}
                   defaultClose={!ultrawide}
                   currentTestConfig={hardpyConfig?.current_test_config}
+                  autoScroll={hardpyConfig?.frontend?.auto_scroll !== false}
                 ></SuiteList>
               </Card>
             )}

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
@@ -95,6 +95,7 @@ interface Props extends WithTranslation {
   db_state: TestRunI;
   defaultClose: boolean;
   currentTestConfig?: string;
+  autoScroll?: boolean;
 }
 
 interface State {
@@ -257,6 +258,7 @@ export class SuiteList extends React.Component<Props, State> {
         test={suite.test}
         defaultOpen={this.elements_count < 5 && !this.props.defaultClose}
         commonTestRunStatus={this.props.db_state.status}
+        autoScroll={this.props.autoScroll}
       />
     );
   }

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
@@ -96,6 +96,7 @@ type Props = {
   test: TestItem;
   defaultOpen: boolean;
   commonTestRunStatus: string | undefined;
+  autoScroll?: boolean;
 } & WithTranslation;
 
 type State = {
@@ -105,6 +106,34 @@ type State = {
 };
 
 const LOADING_ICON_MARGIN = 30;
+
+// Module-level tracker for the most recent user-driven scroll event.
+// Auto-scroll suppresses itself for a short window after any user scroll input
+// so it doesn't yank the operator away from content they're inspecting.
+let lastUserScrollTime = 0;
+let userScrollListenersInstalled = false;
+
+const SCROLL_KEYS = new Set([
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  "ArrowUp",
+  "ArrowDown",
+]);
+
+function installUserScrollListeners(): void {
+  if (userScrollListenersInstalled) return;
+  userScrollListenersInstalled = true;
+  const mark = () => {
+    lastUserScrollTime = Date.now();
+  };
+  window.addEventListener("wheel", mark, { passive: true });
+  window.addEventListener("touchmove", mark, { passive: true });
+  window.addEventListener("keydown", (e) => {
+    if (SCROLL_KEYS.has(e.key)) mark();
+  });
+}
 
 /**
  * TestSuite component displays a collapsible test suite with test cases.
@@ -117,11 +146,70 @@ export class TestSuite extends React.Component<Props, State> {
     </div>
   );
 
+  // Auto-scroll tuning
+  private static readonly USER_SCROLL_SUPPRESS_MS = 3000;
+  private static readonly COLLAPSE_ANIMATION_MS = 300;
+  private static readonly SCROLL_DELAY_MS = 100;
+
   private containerRef = React.createRef<HTMLDivElement>();
+  private scrollTimeout: ReturnType<typeof setTimeout> | null = null;
 
   static defaultProps: Partial<Props> = {
     defaultOpen: true,
   };
+
+  componentDidMount(): void {
+    installUserScrollListeners();
+  }
+
+  componentWillUnmount(): void {
+    if (this.scrollTimeout) {
+      clearTimeout(this.scrollTimeout);
+      this.scrollTimeout = null;
+    }
+  }
+
+  /**
+   * Schedule a smooth scroll to the currently-running case within this suite.
+   * Debounces pending scrolls, respects the user-scroll suppression window,
+   * and extends the delay when the Collapse animation needs to finish first.
+   */
+  private scheduleScrollToRunning(
+    block: ScrollLogicalPosition,
+    waitForCollapse: boolean,
+  ): void {
+    if (this.props.autoScroll === false) return;
+    if (!this.containerRef.current) return;
+
+    const runningIdx = Object.values(this.props.test.cases).findIndex(
+      (c) => c.status === "run"
+    );
+    if (runningIdx === -1) return;
+
+    if (this.scrollTimeout) {
+      clearTimeout(this.scrollTimeout);
+      this.scrollTimeout = null;
+    }
+
+    if (Date.now() - lastUserScrollTime < TestSuite.USER_SCROLL_SUPPRESS_MS) {
+      return;
+    }
+
+    const delay = waitForCollapse
+      ? TestSuite.COLLAPSE_ANIMATION_MS + 100
+      : TestSuite.SCROLL_DELAY_MS;
+
+    this.scrollTimeout = setTimeout(() => {
+      const allRows = this.containerRef.current?.querySelectorAll(".rdt_TableRow");
+      if (allRows && allRows[runningIdx]) {
+        allRows[runningIdx].scrollIntoView({
+          behavior: "smooth",
+          block,
+        });
+      }
+      this.scrollTimeout = null;
+    }, delay);
+  }
 
   /**
    * Renders the TestSuite component.
@@ -186,23 +274,59 @@ export class TestSuite extends React.Component<Props, State> {
     if (this.props.test === prevProps.test) {
       return;
     }
+
+    // Detect a new run starting: all cases have just reset to "ready" (or empty)
+    // while the previous render had at least one active/completed case. Reset
+    // expand state to defaultOpen so a suite kept open by last run's failure
+    // doesn't carry that state into the new run.
+    const allCurrentReady = Object.values(this.props.test.cases).every(
+      (c) => !c.status || c.status === "ready"
+    );
+    const prevHadActivity =
+      !!prevProps.test?.cases &&
+      Object.values(prevProps.test.cases).some(
+        (c) => c.status && c.status !== "ready"
+      );
+    if (allCurrentReady && prevHadActivity) {
+      this.setState({
+        isOpen: false,
+        prevIsOpen: this.state.isOpen,
+        automaticallyOpened: false,
+      });
+      return;
+    }
+
     const anyRunningOrFailed = Object.values(this.props.test.cases).some(
       (test_case) => test_case.status === "run" || test_case.status === "failed"
+    );
+    // "Active" = the suite isn't done yet. Includes "ready" so we don't auto-close
+    // in the gap between one case finishing and the next starting within the same suite.
+    const anyActiveOrFailed = Object.values(this.props.test.cases).some(
+      (test_case) =>
+        test_case.status === "run" ||
+        test_case.status === "failed" ||
+        test_case.status === "ready"
     );
 
     if (anyRunningOrFailed && !this.state.isOpen && !this.state.automaticallyOpened) {
       this.setState({ isOpen: true, prevIsOpen: this.state.isOpen, automaticallyOpened: true });
-      // Don't scroll to suite here - let the test case scroll logic handle it
+      // Schedule scroll to the running case once the Collapse animation finishes.
+      // (The normal scroll block below won't catch this because state.isOpen is
+      // still false synchronously, and by the next prop update justOpened will be
+      // false and runningIndex unchanged.)
+      this.scheduleScrollToRunning("center", true);
       return;
     }
 
-    if (!anyRunningOrFailed && this.state.isOpen && this.state.automaticallyOpened) {
+    // Only auto-close when the suite is genuinely done (no run/failed/ready left).
+    // Failed cases keep the suite open even after the run finishes.
+    if (!anyActiveOrFailed && this.state.isOpen && this.state.automaticallyOpened) {
       this.setState({ isOpen: false, prevIsOpen: this.state.isOpen, automaticallyOpened: false });
       return;
     }
 
-    // Scroll to running test case within the suite
-    if (this.state.isOpen && this.containerRef.current) {
+    // Scroll to running test case within the suite (if enabled via config)
+    if (this.props.autoScroll !== false && this.state.isOpen && this.containerRef.current) {
       const caseEntries = Object.entries(this.props.test.cases);
       const runningIndex = caseEntries.findIndex(
         ([_, test_case]) => test_case.status === "run"
@@ -215,18 +339,32 @@ export class TestSuite extends React.Component<Props, State> {
 
       const justOpened = !prevState.isOpen && this.state.isOpen;
 
-      // If a new test case started running OR suite just opened with a running test, scroll to it
-      if (runningIndex !== -1 && (runningIndex !== prevRunningIndex || justOpened)) {
-        setTimeout(() => {
-          // Find all table rows within this specific test suite
-          const allRows = this.containerRef.current?.querySelectorAll('.rdt_TableRow');
-          if (allRows && allRows[runningIndex]) {
-            allRows[runningIndex].scrollIntoView({
-              behavior: 'smooth',
-              block: 'center',
-            });
-          }
-        }, 400);
+      // Detect when the currently running case appended new measurements / messages
+      // (e.g. a long-running test that streams data). The row grows downward and the
+      // newest content can fall off the bottom of the viewport unless we re-scroll.
+      const runningCase = runningIndex !== -1 ? caseEntries[runningIndex][1] : null;
+      const prevRunningCase = prevRunningIndex !== -1 ? prevCaseEntries[prevRunningIndex][1] : null;
+      const sameRunningCase =
+        runningIndex !== -1 && runningIndex === prevRunningIndex && prevRunningCase != null;
+      const runningCaseGrew =
+        sameRunningCase &&
+        !!runningCase &&
+        (
+          (runningCase.measurements?.length ?? 0) > (prevRunningCase!.measurements?.length ?? 0) ||
+          (runningCase.msg?.length ?? 0) > (prevRunningCase!.msg?.length ?? 0)
+        );
+
+      if (
+        runningIndex !== -1 &&
+        (runningIndex !== prevRunningIndex || justOpened || runningCaseGrew)
+      ) {
+        // 'end' for row-growth (keep newest measurement visible);
+        // 'center' for new running case / just-opened.
+        const scrollBlock: ScrollLogicalPosition =
+          runningCaseGrew && !justOpened && runningIndex === prevRunningIndex
+            ? "end"
+            : "center";
+        this.scheduleScrollToRunning(scrollBlock, justOpened);
       }
     }
   }


### PR DESCRIPTION
## Summary

Our fork's `TestSuite.tsx` adds auto-scroll-to-running-case and auto-expand-on-running/failed behavior that upstream doesn't have. It was producing visible jitter as PouchDB streamed results — viewport yanks, suites blinking between adjacent tests, long streaming tests scrolling off the bottom, the running case getting skipped when a suite first auto-opened, and failed-suite state leaking across runs.

This PR keeps the auto-behavior but makes it well-mannered, and adds a `[frontend].auto_scroll` toggle so fixtures can opt out.

Fixes: [NEX-1203](https://tovala.atlassian.net/browse/NEX-1203)
Parent: [NEX-1173](https://tovala.atlassian.net/browse/NEX-1173)
Based off post-merge `main` (NEX-1194 + NEX-1202).

## Scroll behavior (`TestSuite.tsx`)

- Refactored into `scheduleScrollToRunning(block, waitForCollapse)` helper.
- **Debounce**: cancel pending `scrollTimeout` before scheduling new.
- **User-scroll suppression**: module-level `lastUserScrollTime`, updated on `wheel` / `touchmove` / Page/Home/End/Arrow keys. Auto-scroll no-ops for 3s after operator-driven scroll.
- **Animation-aware delay**: longer timeout when the Collapse animation is still running.
- **Fixed auto-open scroll skip**: when a suite auto-opens because a test inside started running, schedule the scroll right then with `waitForCollapse=true`. Previously the existing block missed this (state.isOpen still false synchronously; `justOpened` false on the next prop update), so the running case wasn't scrolled to until runningIndex advanced.
- **`block: 'center'`** for new-running-case / just-opened; **`block: 'end'`** for content growth on a stable running case (keeps the newest measurement visible during 40+ streaming measurements).
- **`scroll-padding-top: 60px` / `scroll-padding-bottom: 160px`** on `html` and `.bp5-drawer-body` (App.css) so `scrollIntoView` doesn't park a row behind the fixed Navbar or fixed footer.

## Expand/collapse behavior (`TestSuite.tsx`)

- **Auto-close predicate** uses `anyActiveOrFailed` (includes `"ready"`) instead of `anyRunningOrFailed`. Suite stays open across the brief `[passed, ready, ready, ...]` window between adjacent tests in the same module. Previously the suite blinked closed/open each transition.
- **New-run reset**: detect all-cases-back-to-ready while prev had any active case, force `isOpen: false` and `automaticallyOpened: false`. Previously a failed suite stayed open into the next run because the component is keyed by suite name and reused across runs.

## Config flag

- `auto_scroll: bool = True` added to `FrontendConfig` in `hardpy/common/config.py`. Fixtures opt out via `auto_scroll = false` under `[frontend]`.
- Plumbed through App.tsx → SuiteList → TestSuite as `autoScroll` prop.
- Helper no-ops when `autoScroll === false`.

## Demo (`examples/jitter_demo/`)

5-file demo mirroring the existing example convention so the accordion actually triggers (hardpy groups suites by file per `node_info.py:53`). Visible measurements use `disp=True` (the schema default is `False`, which is why the burst initially looked empty).

- `test_1_setup.py` — 3 slow tests (2s each)
- `test_2_smoke.py` — 8 fast tests (0.15s each) stressing scroll debounce + suppression
- `test_3_burst.py` — 1 test streaming 42 measurements at 0.5s
- `test_4_measurements.py` — 4 tests with a mid-run failure (auto-expand trigger)
- `test_5_functional.py` — 4 tests with a late failure

## Upstream alignment

Upstream's `TestSuite.tsx` has *no* auto-scroll or auto-expand — their `componentDidUpdate` only updates a layout column width. We're keeping our fork's richer behavior. Divergence is acknowledged; the helper + tunable constants are easy to retain on future syncs.

## Test plan

- [x] `yarn build` clean.
- [x] TS check shows only the 4 pre-existing errors elsewhere.
- [x] Local run through the 5-module `jitter_demo` with operator-style interaction (scroll up mid-run, manual collapse, etc.) — accordion stays put across adjacent tests; running case scrolls into view when a suite auto-opens; burst measurements track the newest sample; suppression-when-scrolled-away holds for 3s; failed suites reset to closed on new run.
- [ ] Verified on hellraiser / midline / endline (handled in NEX-1201 once a hardpy release ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NEX-1203]: https://tovala.atlassian.net/browse/NEX-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1173]: https://tovala.atlassian.net/browse/NEX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ