### PR TITLE
NEX-1190: Split assertion_msg from assertion_details (clean operator message + engineering longrepr)

### DIFF
--- a/examples/jitter_demo/hardpy.toml
+++ b/examples/jitter_demo/hardpy.toml
@@ -1,7 +1,7 @@
 title = "HardPy TOML config"
 tests_name = "Autoscroll Jitter Demo"
 sound_on = false
-enable_test_pass_fail_modal = false
+enable_test_pass_fail_modal = true
 
 [database]
 user = "dev"

--- a/examples/jitter_demo/test_6_failures.py
+++ b/examples/jitter_demo/test_6_failures.py
@@ -1,0 +1,128 @@
+"""Variety of failing tests to populate the test-completion overlay and exercise
+the scrollable failed-cases list (NEX-1190). Each test demonstrates a different
+failure shape — bare assert, rewritten compare, raised exception, multi-line
+message, long unbreakable string, custom error type, etc.
+"""
+
+import time
+import pytest
+
+import hardpy
+from hardpy import (
+    ComparisonOperation as CompOp,
+    NumericMeasurement,
+    set_case_measurement,
+)
+
+pytestmark = pytest.mark.module_name("Failure Variety")
+
+DWELL = 0.3
+
+
+@pytest.mark.case_name("Bare assert False")
+def test_bare_assert():
+    time.sleep(DWELL)
+    assert False
+
+
+@pytest.mark.case_name("Assert comparison without message")
+def test_assert_compare():
+    time.sleep(DWELL)
+    expected = 42
+    actual = 41
+    assert actual == expected
+
+
+@pytest.mark.case_name("Plain assert with short message")
+def test_plain_assert_short():
+    time.sleep(DWELL)
+    assert False, "Sensor reading invalid"
+
+
+@pytest.mark.case_name("Plain assert with long single-line message")
+def test_plain_assert_long():
+    time.sleep(DWELL)
+    assert False, (
+        "Calibration drift exceeds tolerance: measured -0.42mV vs allowed "
+        "±0.30mV. Probable cause is loose reference connection on TP4. "
+        "Recheck cable seating before retesting."
+    )
+
+
+@pytest.mark.case_name("Multi-line message")
+def test_multiline_message():
+    time.sleep(DWELL)
+    assert False, (
+        "Three independent checks failed:\n"
+        "  - VBAT below threshold (3.1V < 3.3V)\n"
+        "  - Buzzer not responding to PWM\n"
+        "  - LED pattern mismatch on cycle 2"
+    )
+
+
+@pytest.mark.case_name("Path-style string (no spaces)")
+def test_no_space_string():
+    time.sleep(DWELL)
+    assert False, (
+        "/var/log/hardpy/fixture_logs/2026-05-12/test_run_abcd1234efgh5678/"
+        "stage_5/raw_capture_failure.bin"
+    )
+
+
+@pytest.mark.case_name("RuntimeError raised")
+def test_raise_runtime_error():
+    time.sleep(DWELL)
+    raise RuntimeError("Stepper motor stalled at position 1400")
+
+
+@pytest.mark.case_name("ValueError raised")
+def test_raise_value_error():
+    time.sleep(DWELL)
+    raise ValueError("Serial number checksum mismatch — expected 0xAB12, got 0xCD34")
+
+
+@pytest.mark.case_name("hardpy.ErrorCode raised")
+def test_error_code():
+    time.sleep(DWELL)
+    assert False, hardpy.ErrorCode(101, "Printer not found — check USB cable")
+
+
+@pytest.mark.case_name("Numeric measurement out of range")
+def test_meas_fail():
+    time.sleep(DWELL)
+    meas = NumericMeasurement(
+        value=2.84,
+        name="Output voltage",
+        unit="V",
+        operation=CompOp.GELE,
+        lower_limit=3.20,
+        upper_limit=3.40,
+        disp=True,
+    )
+    set_case_measurement(meas)
+    assert meas.result, "Output voltage out of spec — regulator may be faulty"
+
+
+@pytest.mark.case_name("Failure with embedded asserted expression")
+def test_embedded_assert_text():
+    time.sleep(DWELL)
+    # The user's message contains the substring "assert " — verify the
+    # decomposition stripper doesn't over-eagerly truncate inside it.
+    assert False, "Test plan says: do not assert without a clear reason"
+
+
+@pytest.mark.case_name("Long traceback through helper")
+def test_long_traceback():
+    """Indirect failure to produce a deeper stack in assertion_details."""
+    time.sleep(DWELL)
+
+    def step_a():
+        return step_b()
+
+    def step_b():
+        return step_c()
+
+    def step_c():
+        raise RuntimeError("Inner helper aborted unexpectedly")
+
+    step_a()

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestData.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestData.tsx
@@ -117,7 +117,9 @@ export function TestData(props: Readonly<Props>): React.ReactElement {
         );
       })}
       
-      {/* Render assertions last */}
+      {/* Render assertions last. assertion_msg is the clean operator-facing
+          user message (NEX-1190); the full longrepr with stack frames lives in
+          assertion_details on the case and is for the saved report only. */}
       {props.assertion_msg && (
         <Tag
           key={"assertion"}
@@ -126,7 +128,7 @@ export function TestData(props: Readonly<Props>): React.ReactElement {
           multiline={true}
           intent="warning"
         >
-          {props.assertion_msg.split("\n")[0]}
+          {props.assertion_msg}
         </Tag>
       )}
     </div>

--- a/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
+++ b/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
@@ -48,8 +48,13 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
       overlay.focus();
     }
 
+    // Only dismiss on confirm-style keys. Scroll keys (PageUp/Down, arrows,
+    // Home/End) must be passed through so the operator can review a long list
+    // of failed cases.
+    const DISMISS_KEYS = new Set(["Enter", " ", "Spacebar", "Escape", "Esc"]);
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (isVisible) {
+      if (!isVisible) return;
+      if (DISMISS_KEYS.has(e.key)) {
         e.preventDefault();
         onDismiss();
       }
@@ -108,6 +113,9 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
     marginTop: "20px",
     width: "80%",
     maxWidth: "800px",
+    cursor: "default", // override the parent overlay's pointer cursor inside the scroll area
+    scrollbarColor: "rgba(255,255,255,0.6) rgba(255,255,255,0.1)", // visible against the red/green backdrop
+    scrollbarWidth: "auto",
   };
 
   const caseItemStyle: React.CSSProperties = {
@@ -147,9 +155,18 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
       </div>
 
       {!testPassed && failedTestCases.length > 0 && (
-        <div style={failedCasesStyle}>
+        <div
+          style={failedCasesStyle}
+          // Stop click/touch/scroll events from bubbling to the overlay's
+          // click-to-dismiss handler. Operator can scroll and select text
+          // inside the failure list without dismissing the modal.
+          onClick={(e) => e.stopPropagation()}
+          onWheel={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+        >
           <h3 style={{ marginTop: 0, marginBottom: "20px", fontSize: "24px" }}>
-            Failed Test Cases:
+            Failed Test Cases ({failedTestCases.length}):
           </h3>
           {failedTestCases.map((testCase, index) => (
             <div key={index} style={caseItemStyle}>

--- a/hardpy/pytest_hardpy/db/const.py
+++ b/hardpy/pytest_hardpy/db/const.py
@@ -24,6 +24,7 @@ class DatabaseField(str, Enum):
     TIMEZONE = "timezone"
     MSG = "msg"
     ASSERTION_MSG = "assertion_msg"
+    ASSERTION_DETAILS = "assertion_details"
     PART_NUMBER = "part_number"
     SERIAL_NUMBER = "serial_number"
     SUB_UNITS = "sub_units"

--- a/hardpy/pytest_hardpy/db/schema/v1.py
+++ b/hardpy/pytest_hardpy/db/schema/v1.py
@@ -31,7 +31,12 @@ class IBaseResult(BaseModel):
 class CaseStateStore(IBaseResult):
     """Test case description."""
 
+    # `assertion_msg` is the operator-facing user message only (e.g. the second
+    # arg of `assert expr, "msg"`). Kept short and clean for the operator panel.
+    # `assertion_details` carries the full pytest longrepr (decomposition + stack
+    # frames) for engineering review via the saved report.
     assertion_msg: str | None = None
+    assertion_details: str | None = None
     msg: dict | None = None
     measurements: list[NumericMeasurement | StringMeasurement] = []
     chart: Chart | None = None
@@ -44,6 +49,7 @@ class CaseRunStore(IBaseResult):
     """Test case description with artifact."""
 
     assertion_msg: str | None = None
+    assertion_details: str | None = None
     msg: dict | None = None
     measurements: list[NumericMeasurement | StringMeasurement] = []
     chart: Chart | None = None

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -140,6 +140,11 @@ class HardpyPlugin:
         self._is_critical_not_passed = False
         self._start_args = {}
         self._appliance_version = None
+        # Stash of (clean message, full longrepr) per (module_id, case_id) set by
+        # pytest_runtest_makereport (where call.excinfo is available) and consumed
+        # by pytest_runtest_logreport. Lets us record both the operator-facing
+        # message and the engineering-facing details with one capture point.
+        self._assertion_stash: dict[tuple[str, str], tuple[str, str]] = {}
 
         if system() == "Linux":
             signal.signal(signal.SIGTERM, self._stop_handler)
@@ -369,6 +374,13 @@ class HardpyPlugin:
         if is_dut_failure and caused_dut_failure_id is None:
             self._reporter.set_caused_dut_failure_id(module_id, case_id)
 
+        # Stash assertion data for logreport. If the final attempt still has an
+        # excinfo, the case failed; capture both the clean user message and the
+        # full pytest longrepr so logreport can populate both schema fields.
+        if call.excinfo is not None:
+            clean_msg, details = self._extract_assertion_data(call.excinfo)
+            self._assertion_stash[(module_id, case_id)] = (clean_msg, details)
+
     # Reporting hooks
 
     def pytest_runtest_logreport(self, report: TestReport) -> bool | None:
@@ -390,8 +402,18 @@ class HardpyPlugin:
         if report.skipped is False or is_skipped_by_plugin is False:
             self._reporter.set_case_stop_time(module_id, case_id)
 
-        assertion_msg = self._decode_assertion_msg(report.longrepr)
-        self._reporter.set_assertion_msg(module_id, case_id, assertion_msg)
+        # Prefer the data stashed by pytest_runtest_makereport (where excinfo is
+        # accessible so we can split the operator message from the longrepr
+        # cleanly). Fall back to parsing report.longrepr for cases where the
+        # stash is missing (e.g. teardown/setup failures that bypass makereport).
+        stashed = self._assertion_stash.pop((module_id, case_id), None)
+        if stashed is not None:
+            clean_msg, details = stashed
+            self._reporter.set_assertion_msg(module_id, case_id, clean_msg)
+            self._reporter.set_assertion_details(module_id, case_id, details)
+        else:
+            assertion_msg = self._decode_assertion_msg(report.longrepr)
+            self._reporter.set_assertion_msg(module_id, case_id, assertion_msg)
         self._reporter.set_progress(self._progress.calculate(report.nodeid))
         self._results[module_id][case_id] = report.outcome
 
@@ -512,6 +534,55 @@ class HardpyPlugin:
         self._results[module_id][case_id] = case_status
         self._reporter.set_case_status(module_id, case_id, case_status)
         return is_case_stopped
+
+    _ANSI_ESCAPE = re_compile(
+        r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])",
+    )
+
+    def _extract_assertion_data(
+        self,
+        excinfo: ExceptionInfo[BaseException],
+    ) -> tuple[str, str]:
+        """Extract clean operator message + full engineering longrepr from a pytest excinfo.
+
+        Returns:
+            tuple[clean_msg, details]:
+              - clean_msg: the user's exception message (e.g. the second arg of
+                ``assert expr, msg``). No ``AssertionError:`` prefix, no pytest
+                assert decomposition, no stack frames.
+              - details: full pytest longrepr (style="long", showlocals=False),
+                ANSI-stripped. Includes the assert decomposition and stack frames.
+                Stored on the case for engineering review via the saved report.
+        """
+        # str() on the exception instance dispatches to __str__, which for the
+        # standard exception hierarchy returns just args[0] without the type
+        # prefix. Custom message types like hardpy.ErrorCode override __str__
+        # to return their own short form.
+        clean_msg = str(excinfo.value)
+        # When pytest's assertion rewriting is enabled (default), AssertionError
+        # args[0] is `"{user_msg}\nassert <expr>\n + where ..."` — the user's
+        # message with the decomposition appended. Strip everything from the
+        # decomposition marker onward so the operator only sees their own text.
+        # Heuristic — fails only if a user message itself contains "\nassert ",
+        # which is exceedingly rare; worst case is truncation.
+        decomp_idx = clean_msg.find("\nassert ")
+        if decomp_idx >= 0:
+            clean_msg = clean_msg[:decomp_idx]
+        # Bare `assert False` (no user message) produces a string that STARTS
+        # with "assert " (the decomposition alone). Drop it so the placeholder
+        # branch fires.
+        if clean_msg.startswith("assert "):
+            clean_msg = ""
+        # Bare assert (or empty AssertionError) — give the operator panel a
+        # generic placeholder so the tag isn't blank. Non-Assertion exceptions
+        # with no message keep the empty form: that's a code bug to investigate
+        # via assertion_details, not an operator-actionable fail mode.
+        if not clean_msg and issubclass(excinfo.type, AssertionError):
+            clean_msg = "Assert Failed"
+        details = self._ANSI_ESCAPE.sub(
+            "", str(excinfo.getrepr(style="long", showlocals=False)),
+        )
+        return clean_msg, details
 
     def _decode_assertion_msg(
         self,

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -543,7 +543,7 @@ class HardpyPlugin:
         self,
         excinfo: ExceptionInfo[BaseException],
     ) -> tuple[str, str]:
-        """Extract clean operator message + full engineering longrepr from a pytest excinfo.
+        """Extract clean operator message and full engineering longrepr.
 
         Returns:
             tuple[clean_msg, details]:

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -101,6 +101,10 @@ class HookReporter(BaseReporter):
     def set_assertion_msg(self, module_id: str, case_id: str, msg: str | None) -> None:
         """Set case assertion message.
 
+        Operator-facing: the user's clean exception message (no class prefix, no
+        pytest assert decomposition, no stack frames). What the operator panel
+        renders.
+
         Args:
             module_id (str): test module id
             case_id (str): test case id
@@ -114,6 +118,30 @@ class HookReporter(BaseReporter):
             DF.ASSERTION_MSG,
         )
         self.set_doc_value(key, msg)
+
+    def set_assertion_details(
+        self, module_id: str, case_id: str, details: str | None,
+    ) -> None:
+        """Set case assertion details (full pytest longrepr for engineering).
+
+        Engineering-facing: pytest's full failure representation including assert
+        decomposition and stack frames. Carried through to the saved report via
+        ``model_dump()`` for post-run review. The operator panel does not render
+        this.
+
+        Args:
+            module_id (str): test module id
+            case_id (str): test case id
+            details (str | None): full longrepr text
+        """
+        key = self.generate_key(
+            DF.MODULES,
+            module_id,
+            DF.CASES,
+            case_id,
+            DF.ASSERTION_DETAILS,
+        )
+        self.set_doc_value(key, details)
 
     def add_case(self, node_info: NodeInfo) -> None:
         """Add test case to document.

--- a/tests/test_plugin/test_error_code.py
+++ b/tests/test_plugin/test_error_code.py
@@ -34,7 +34,13 @@ def test_fill_error_code(pytester: Pytester, hardpy_opts: list[str]):
 
             case_id = "test_fill_error_code"
             assertion_msg_1 = report.modules[module_id].cases[case_id].assertion_msg
-            assert "AssertionError: a" in assertion_msg_1
+            # NEX-1190: assertion_msg is the clean user message only (no
+            # "AssertionError: " prefix, no pytest decomposition). The full
+            # longrepr lives in the new assertion_details field.
+            assert assertion_msg_1 == "a"
+            assertion_details_1 = report.modules[module_id].cases[case_id].assertion_details
+            assert assertion_details_1 is not None
+            assert "AssertionError" in assertion_details_1
     """,
     )
     result = pytester.runpytest(*hardpy_opts)


### PR DESCRIPTION
## Summary

The operator panel was rendering pytest's full assertion-rewriting decomposition along with the user's message — multi-line, noisy, hard for floor operators to parse. The schema only had one field (`assertion_msg`) for the failure, and the report pipeline pulled from it, so we couldn't strip the noise without losing engineering context from the saved report.

This PR splits the capture into two schema fields:

- **`assertion_msg`** — clean user message only, what the operator panel renders
- **`assertion_details`** — full pytest longrepr (stack frames + decomposition), carried into the saved report for engineering review

Fixes: [NEX-1190](https://tovala.atlassian.net/browse/NEX-1190)
Parent: [NEX-1173](https://tovala.atlassian.net/browse/NEX-1173)
Blocks (forward-compat for): [NEX-1206](https://tovala.atlassian.net/browse/NEX-1206) — i18n/dual-language rendering

## Behavior matrix

| Test code | `assertion_msg` (panel) | `assertion_details` (report) |
|---|---|---|
| `assert False, "Voltage out of spec"` | `Voltage out of spec` | full longrepr |
| `assert False` (bare) | `Assert Failed` | full longrepr |
| `assert x == y` (pytest rewrites) | `Assert Failed` *(see notes)* | full longrepr |
| `raise RuntimeError("Pump offline")` | `Pump offline` | full longrepr |
| `raise hardpy.ErrorCode(1, "Printer not found")` | `Printer not found` | full longrepr |
| `raise RuntimeError()` (no message) | *(empty — code bug, see details)* | full longrepr |

The pytest rewriter on `assert x == y` produces `"assert 1 == 2"` which my heuristic detects as a bare-assert decomposition and clears, then the AssertionError fallback writes `"Assert Failed"`. Lossy on purpose — confirmed with Shawn that bare-asserts will be cleaned up in follow-up work.

## Plumbing changes

- `hardpy/pytest_hardpy/db/schema/v1.py` — `assertion_details: str | None` added to `CaseStateStore` and `CaseRunStore`. Nullable so existing docs deserialize fine; old hardpy clients writing to the same DB coexist with new ones during rollout.
- `hardpy/pytest_hardpy/db/const.py` — `DF.ASSERTION_DETAILS` constant.
- `hardpy/pytest_hardpy/plugin.py` — new `_extract_assertion_data(excinfo) → (clean_msg, details)`:
  - `clean_msg = str(excinfo.value)`, then strip pytest's assertion-rewriting decomposition (`\nassert <expr>\n + where ...` baked into args[0] by the rewriter). Bare-assert fallback writes `"Assert Failed"`.
  - `details = str(excinfo.getrepr(style="long", showlocals=False))` with ANSI codes stripped — full longrepr.
  - Data captured in `pytest_runtest_makereport` (where `call.excinfo` is accessible), stashed per-(module_id, case_id), consumed in `pytest_runtest_logreport`. Existing `_decode_assertion_msg` kept as a fallback for setup/teardown failures that bypass makereport.
- `hardpy/pytest_hardpy/reporter/hook_reporter.py` — new `set_assertion_details()` method.
- `hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestData.tsx` — `.split("\n")[0]` truncation removed. `assertion_msg` rendered verbatim; `pre-wrap` from NEX-1202's `TAG_ELEMENT_STYLE` handles any embedded newlines.
- `tests/test_plugin/test_error_code.py` — updated to assert the new behavior (clean message in `assertion_msg`, full longrepr in `assertion_details`).

Report pipeline (`couchdb_loader.py`, `stand_cloud_loader.py`) uses `report.model_dump()` and picks up the new field automatically — **no loader changes needed**. Saved reports become strictly richer than today.

## Pass/fail modal scroll fix (bundled — second commit)

While verifying the end-of-run modal against a long failure list, found two issues in `TestCompletionOverlay.tsx`:

- Window keydown listener dismissed on **any** key, so PageUp/Down/arrows used to scroll the failed-cases list closed the modal instead.
- `onClick={onDismiss}` on the overlay root caught clicks anywhere — including inside the scrollable failed-cases container. Touch-scroll on a touchscreen panel would dismiss mid-gesture.

Fix:
- Whitelist dismiss keys (Enter, Space, Escape); other keys pass through.
- `stopPropagation` on the failed-cases container for click, wheel, and touch events.
- `cursor: default` inside the scroll area (parent overlay keeps `cursor: pointer` for dismiss affordance).
- `scrollbarColor` so the scrollbar is visible against the red/green backdrop.
- Header shows count: `"Failed Test Cases (14):"`.

## Demo expansion

`examples/jitter_demo/test_6_failures.py` — 12 new deliberately-failing tests covering the full variety of failure shapes: bare assert, rewritten compare, plain assert (short + long single-line + multi-line), no-space path string, raised RuntimeError / ValueError, hardpy.ErrorCode, numeric measurement failure, message containing the substring "assert " (verifies the decomposition stripper doesn't over-truncate), and a helper-chain failure for a deeper stack in `assertion_details`. Combined with the existing 2 failures the demo now produces ~14 failed cases — enough to overflow the overlay's `60vh maxHeight` and verify scroll behavior.

Also `enable_test_pass_fail_modal = true` set on the demo so the end-of-run modal surfaces for visual verification.

## i18n forward-compat

`assertion_msg` type stays `str | None` deliberately so NEX-1206 (dual-language rendering, already in flight in a parallel thread) can widen to `str | dict[str, str] | None` without a second schema migration. `assertion_details` stays plain `str` — developer-facing, not translated.

## Test plan

- [x] `yarn build` clean.
- [x] TS check shows only the 4 pre-existing errors elsewhere; nothing new in this PR.
- [x] Python `model_dump()` round-trips both fields.
- [x] Existing `test_plugin/test_error_code.py` rewritten and passing (asserts clean message in `assertion_msg`, "AssertionError" substring present in `assertion_details`).
- [x] Local run through `jitter_demo`'s 32 tests (14 failing): operator panel renders only clean user messages for all failure shapes; end-of-run modal scrolls cleanly through all 14 failures via wheel / PageDown / arrow keys; CouchDB doc shows populated `assertion_details` with full longrepr.
- [ ] Verified on hellraiser / midline / endline (NEX-1201, once a hardpy release ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NEX-1190]: https://tovala.atlassian.net/browse/NEX-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1173]: https://tovala.atlassian.net/browse/NEX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-1206]: https://tovala.atlassian.net/browse/NEX-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ