### PR TITLE
NEX-1206: Polish fail overlay — inline title, scroll keys

### DIFF
--- a/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
+++ b/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
@@ -80,6 +80,8 @@ interface TranslatedTextProps {
   /** Skip the default secondary styling (opacity / lighter weight / smaller font).
    * Use when the caller wants to fully control secondary rendering. */
   noDefaultSecondaryStyle?: boolean;
+  /** Render primary and secondary side-by-side instead of stacked vertically. */
+  inline?: boolean;
   /** Whether the secondary row may suppress when identical to primary. Default true. */
   suppressDuplicate?: boolean;
   className?: string;
@@ -98,6 +100,7 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
   primaryStyle,
   secondaryStyle,
   noDefaultSecondaryStyle = false,
+  inline = false,
   suppressDuplicate = true,
   className,
 }) => {
@@ -144,7 +147,12 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
   return (
     <span
       className={className}
-      style={{ display: "inline-flex", flexDirection: "column", alignItems: "inherit" }}
+      style={{
+        display: "inline-flex",
+        flexDirection: inline ? "row" : "column",
+        alignItems: inline ? "baseline" : "inherit",
+        columnGap: inline ? "0.5em" : undefined,
+      }}
     >
       <span style={primaryStyle}>{primary}</span>
       {displaySecondary && (

--- a/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
+++ b/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
@@ -27,6 +27,8 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
   failedTestCases = [],
   onDismiss,
 }) => {
+  const failedListRef = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
     if (isVisible && testPassed) {
       // Auto-dismiss after 5 seconds only for PASS
@@ -49,15 +51,45 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
       overlay.focus();
     }
 
-    // Only dismiss on confirm-style keys. Scroll keys (PageUp/Down, arrows,
-    // Home/End) must be passed through so the operator can review a long list
-    // of failed cases.
+    // Only dismiss on confirm-style keys. Scroll keys route to the failures
+    // list below so the operator can review a long list of failed cases
+    // without leaving the overlay.
     const DISMISS_KEYS = new Set(["Enter", " ", "Spacebar", "Escape", "Esc"]);
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!isVisible) return;
       if (DISMISS_KEYS.has(e.key)) {
         e.preventDefault();
         onDismiss();
+        return;
+      }
+      const list = failedListRef.current;
+      if (!list) return;
+      const ARROW_STEP = 60;
+      switch (e.key) {
+        case "ArrowDown":
+          list.scrollBy({ top: ARROW_STEP, behavior: "smooth" });
+          e.preventDefault();
+          break;
+        case "ArrowUp":
+          list.scrollBy({ top: -ARROW_STEP, behavior: "smooth" });
+          e.preventDefault();
+          break;
+        case "PageDown":
+          list.scrollBy({ top: list.clientHeight * 0.9, behavior: "smooth" });
+          e.preventDefault();
+          break;
+        case "PageUp":
+          list.scrollBy({ top: -list.clientHeight * 0.9, behavior: "smooth" });
+          e.preventDefault();
+          break;
+        case "Home":
+          list.scrollTo({ top: 0, behavior: "smooth" });
+          e.preventDefault();
+          break;
+        case "End":
+          list.scrollTo({ top: list.scrollHeight, behavior: "smooth" });
+          e.preventDefault();
+          break;
       }
     };
 
@@ -92,28 +124,28 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
   };
 
   const titleStyle: React.CSSProperties = {
-    fontSize: "120px",
+    fontSize: "56px",
     fontWeight: "bold",
-    marginBottom: "20px",
     textShadow: "0 4px 8px rgba(0,0,0,0.3)",
+    lineHeight: 1,
   };
 
   const subtitleStyle: React.CSSProperties = {
-    fontSize: "48px",
+    fontSize: "32px",
     fontWeight: "bold",
-    marginBottom: "40px",
     textShadow: "0 2px 4px rgba(0,0,0,0.3)",
+    lineHeight: 1,
   };
 
   const failedCasesStyle: React.CSSProperties = {
-    maxHeight: "60vh",
+    maxHeight: "80vh",
     overflowY: "auto",
     backgroundColor: "rgba(0,0,0,0.3)",
     borderRadius: "8px",
     padding: "20px",
-    marginTop: "20px",
-    width: "80%",
-    maxWidth: "800px",
+    marginTop: "16px",
+    width: "85%",
+    maxWidth: "1000px",
     cursor: "default", // override the parent overlay's pointer cursor inside the scroll area
     scrollbarColor: "rgba(255,255,255,0.6) rgba(255,255,255,0.1)", // visible against the red/green backdrop
     scrollbarWidth: "auto",
@@ -153,10 +185,12 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
         primaryStyle={titleStyle}
         secondaryStyle={subtitleStyle}
         noDefaultSecondaryStyle
+        inline
       />
 
       {!testPassed && failedTestCases.length > 0 && (
         <div
+          ref={failedListRef}
           style={failedCasesStyle}
           // Stop click/touch/scroll events from bubbling to the overlay's
           // click-to-dismiss handler. Operator can scroll and select text

--- a/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
+++ b/hardpy/hardpy_panel/frontend/src/test_completion/TestCompletionOverlay.tsx
@@ -28,6 +28,37 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
   onDismiss,
 }) => {
   const failedListRef = React.useRef<HTMLDivElement>(null);
+  const pointerStartRef = React.useRef<
+    { x: number; y: number; id: number } | null
+  >(null);
+  // Tap-vs-swipe threshold: swipes beyond this don't dismiss, so an operator
+  // can drag-scroll the failures list (or the screen at large) without the
+  // overlay vanishing under their finger.
+  const TAP_THRESHOLD_PX = 10;
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    // Touches/clicks that originate inside the failures list are scroll
+    // intentions — let native scrolling handle them and don't track for dismiss.
+    if (failedListRef.current?.contains(e.target as Node)) {
+      pointerStartRef.current = null;
+      return;
+    }
+    pointerStartRef.current = { x: e.clientX, y: e.clientY, id: e.pointerId };
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const start = pointerStartRef.current;
+    pointerStartRef.current = null;
+    if (!start || start.id !== e.pointerId) return;
+    const moved = Math.hypot(e.clientX - start.x, e.clientY - start.y);
+    if (moved < TAP_THRESHOLD_PX) {
+      onDismiss();
+    }
+  };
+
+  const handlePointerCancel = () => {
+    pointerStartRef.current = null;
+  };
 
   React.useEffect(() => {
     if (isVisible && testPassed) {
@@ -173,7 +204,9 @@ const TestCompletionOverlay: React.FC<TestCompletionOverlayProps> = ({
   return (
     <div
       style={overlayStyle}
-      onClick={onDismiss}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       className={Classes.DARK}
       // Dialog is used to ensure start/stop button doesnt get pressed when dismissing
       role="dialog"


### PR DESCRIPTION
## Summary
- Follow-up polish to the fail-screen overlay shipped in #6 (NEX-1206)
- Shrinks the PASS/FAIL title block so the failed-tests list dominates the screen, where the operator's attention actually needs to be
- Routes Arrow/PageUp/PageDown/Home/End to scroll the failures list instead of being swallowed by the focused overlay div
- Switches dismiss from `onClick` to tap-vs-swipe pointer detection so touchscreen operators can drag-scroll without dismissing the overlay under their own finger

## Changes
**`TranslatedText.tsx`** — new `inline` prop. When set, primary + secondary render side-by-side with a column-gap and `alignItems: baseline` instead of the default stacked column.

**`TestCompletionOverlay.tsx`**
- Title: 120px → 56px. Subtitle: 48px → 32px. Removed `marginBottom` and inlined via the new prop, so "失败 FAIL" sits horizontally as one compact banner.
- Failures list: `maxHeight` 60vh → 80vh, `maxWidth` 800 → 1000, slight `marginTop` reduction. Reclaims the vertical space the oversized title was eating.
- Added `failedListRef` and explicit keydown handling: ArrowUp/Down (60px), PageUp/Down (~90% viewport), Home/End — all scroll the failures list smoothly. Dismiss keys (Enter/Space/Escape) still dismiss.
- Swapped outer `onClick={onDismiss}` for `onPointerDown`/`onPointerUp` with a 10px tap-vs-swipe threshold. Pointers starting inside the failures list aren't tracked at all, so native list scrolling is untouched.

## Test plan
- [ ] On a fail run with a long failure list (jitter_demo's 10+ cases), verify title is compact and failures fill the modal
- [ ] Arrow keys scroll the failures list, do not dismiss
- [ ] PageUp/Down jumps roughly one viewport
- [ ] Home/End jump to ends
- [ ] Enter/Space/Escape still dismiss
- [ ] Click (mouse) outside the list still dismisses
- [ ] On a touchscreen: swipe to scroll the failures list does NOT dismiss
- [ ] On a touchscreen: tap outside the list dismisses
- [ ] Pass screen still renders cleanly (title-only, no list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
