### PR TITLE
NEX-1204: Arrow-key nav + Pass/Fail focus swap + popover SPACE guard

### DIFF
--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -78,6 +78,10 @@ function App(): JSX.Element {
   const [showConfigOverlay, setShowConfigOverlay] = React.useState(false);
   const [hardpyConfig, setHardpyConfig] = React.useState<any>(null);
 
+  // Settings (cog) popover — controlled so F2 (long-press UP on the GPIO
+  // controller) can open it without a mouse. See NEX-1204.
+  const [showSettingsMenu, setShowSettingsMenu] = React.useState(false);
+
   // Test completion overlay state
   const [showCompletionOverlay, setShowCompletionOverlay] = React.useState(false);
   const [testCompletionData, setTestCompletionData] = React.useState<{
@@ -308,13 +312,29 @@ function App(): JSX.Element {
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Let Blueprint's popover handle its own keys (e.g. ESC to dismiss,
+      // arrow keys to navigate MenuItems). NEX-1204.
+      if (showSettingsMenu) {
+        return;
+      }
       if (isDialogOpen()) {
         return;
       }
 
-      if (e.key === "ArrowLeft") {
+      // ArrowLeft is the legacy GPIO-LEFT mapping; Escape is the new mapping
+      // (GPIO long-press LEFT will emit ESC after hardpy-appliance lands the
+      // remap). Both open Select Test Configuration. NEX-1204.
+      if (e.key === "ArrowLeft" || e.key === "Escape") {
         e.preventDefault();
         setShowConfigOverlay(true);
+        return;
+      }
+
+      // F2 opens the settings cog menu (long-press UP on the GPIO controller
+      // will emit F2 after hardpy-appliance lands). NEX-1204.
+      if (e.key === "F2") {
+        e.preventDefault();
+        setShowSettingsMenu(true);
       }
     };
 
@@ -322,7 +342,7 @@ function App(): JSX.Element {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [showSettingsMenu]);
 
   /**
    * Renders the database content.
@@ -640,7 +660,11 @@ function App(): JSX.Element {
               }}
             />
           )}
-          <Popover content={renderSettingsMenu()}>
+          <Popover
+            content={renderSettingsMenu()}
+            isOpen={showSettingsMenu}
+            onInteraction={(nextOpenState) => setShowSettingsMenu(nextOpenState)}
+          >
             <Button className="bp3-minimal" icon="cog" />
           </Popover>
         </Navbar.Group>

--- a/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
+++ b/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
@@ -208,6 +208,13 @@ class StartStopButton extends React.Component<Props, State> {
       return;
     }
 
+    // Don't handle space when focus is inside a popover or menu. Blueprint
+    // MenuItems render as anchors (not in `interactiveElements`), so without
+    // this guard SPACE on a focused MenuItem would start a test. NEX-1204.
+    if (target.closest('.bp3-popover, [role="menu"]')) {
+      return;
+    }
+
     event.preventDefault();
     const is_testing_in_progress = this.props.testing_status == "run";
     is_testing_in_progress ? this.hardpy_stop() : this.hardpy_start();

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -498,6 +498,11 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
   const [hasHTML, setHasHTML] = useState(false);
   const maxDimensions = useRef(BASE_DIALOG_DIMENSIONS);
 
+  // Pass/Fail button refs — used for arrow-key focus swap so the operator
+  // can drive the dialog with only arrow keys + start button. NEX-1204.
+  const passBtnRef = useRef<HTMLButtonElement>(null);
+  const failBtnRef = useRef<HTMLButtonElement>(null);
+
   const widgetType = props.widget_type ?? WidgetType.Base;
   const maxSizeFactor =
     screenWidth < screenHeight ? PHONE_SCALE_FACTOR : MONITOR_SCALE_FACTOR;
@@ -992,14 +997,28 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         {props.pass_fail ? (
-          <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+          <div
+            style={{ display: "flex", justifyContent: "space-between", width: "100%" }}
+            onKeyDown={(e) => {
+              // Arrow-key focus swap between Pass and Fail. SPACE/ENTER on the
+              // focused button fire its onClick natively. NEX-1204.
+              if (e.key === "ArrowLeft") {
+                e.preventDefault();
+                passBtnRef.current?.focus();
+              } else if (e.key === "ArrowRight") {
+                e.preventDefault();
+                failBtnRef.current?.focus();
+              }
+            }}
+          >
             <Button
               intent="success"
               text={t('operatorDialog.pass')}
               onClick={() => handlePassFail(true)}
               large
-              style={{ 
-                height: "80px", 
+              ref={passBtnRef}
+              style={{
+                height: "80px",
                 minWidth: "120px",
                 fontSize: "16px",
                 fontWeight: "bold"
@@ -1010,8 +1029,10 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
               text={t('operatorDialog.fail')}
               onClick={() => handlePassFail(false)}
               large
-              style={{ 
-                height: "80px", 
+              autoFocus
+              ref={failBtnRef}
+              style={{
+                height: "80px",
                 minWidth: "120px",
                 fontSize: "16px",
                 fontWeight: "bold"


### PR DESCRIPTION
## Summary

Hardpy half of [NEX-1204](https://tovala.atlassian.net/browse/NEX-1204) — making the operator panel safe to drive with arrow keys + start button only, on hellbraiser / midline / endline.

- **App.tsx**: dual `ArrowLeft` + `Escape` openers for Select Test Configuration (migration aid — `ArrowLeft` drops in a follow-up once the GPIO LEFT→ESC remap is in the field). Add `F2` handler that opens the cog settings popover; lift the cog `<Popover>` to controlled state. Bail the global keydown effect when settings is open so Blueprint owns its own ESC dismissal.
- **DialogBox.tsx**: in `pass_fail` mode, give Pass/Fail buttons refs and `autoFocus` Fail by default. Arrow Left/Right swaps focus between them; SPACE/ENTER fires the focused button natively. Defaulting focus to Fail prevents absent-minded ENTER from passing a defective unit.
- **StartStop.tsx**: `handleSpaceKey` bails when focus is inside `.bp3-popover` or `[role="menu"]`. Blueprint `MenuItem`s render as anchors and weren't covered by the existing interactive-element guard, so SPACE on a focused MenuItem was starting a test — likely the original "critical fails" symptom.

Version bump and release are happening in a separate PR.

## Test plan

- [ ] Press Escape on the home screen → Select Test Configuration overlay opens.
- [ ] Press ArrowLeft on the home screen → same overlay opens (legacy behavior preserved).
- [ ] Press F2 on the home screen → cog menu opens; ArrowUp/Down navigates MenuItems; ENTER selects.
- [ ] With cog menu open, press SPACE → no test starts; pressing ESC closes the menu only.
- [ ] In a pass/fail dialog, Fail starts focused; ArrowLeft moves focus to Pass; ArrowRight back to Fail; ENTER fires whichever has focus.
- [ ] No regressions: existing arrow-key navigation inside \`TestConfigOverlay\` (Up/Down to scroll, Right to select) still works.
- [ ] \`yarn tsc --noEmit\` — no new errors introduced (4 pre-existing errors remain, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NEX-1204]: https://tovala.atlassian.net/browse/NEX-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ