### PR TITLE
Release v0.15.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.15.2.12"
+    version = "0.15.2.13"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]


### PR DESCRIPTION
## Summary

Cut fork release `v0.15.2.13`. Bumps `pyproject.toml` from `0.15.2.12` → `0.15.2.13` so the `release-local.yml` git-tag-check passes when we push the tag.

## What's in this release

19 commits since `v0.15.2.12` (`6e13ec7`):

- **NEX-1194** (#2) — Port upstream `full_size_button` flag for per-fixture start button size
- **NEX-1202** (#3) — Wrap long strings in operator panel tags
- **NEX-1203** (#4) — Fix operator-panel autoscroll/autoexpand jitter + add `auto_scroll` config
- **NEX-1190** (#5) — Split `assertion_msg` from `assertion_details`; expand jitter_demo failure cases
- **NEX-1206** (#6) — Add dual-language stacked rendering (i18n) to operator panel; switch fixture catalog from TOML to JSON; add Thai + Burmese translations
- **NEX-1206** (#7) — Fail-overlay polish: inline title, keyboard scroll routing, tap-vs-swipe touchscreen dismiss
- **NEX-1204** (#8) — ESC/F2 keyboard nav, Pass/Fail focus swap, popover SPACE guard

## Release procedure

Once this merges:

1. `git checkout main && git pull`
2. `git tag v0.15.2.13`
3. `git push origin v0.15.2.13`
4. The `Release (Local Fork)` workflow runs: tag-check → build (yarn + python -m build) → GH release with wheel + sdist attached at https://github.com/tovala/hardpy/releases/tag/v0.15.2.13
5. Optionally `gh release edit v0.15.2.13 --notes-file <somefile>` to populate release notes (default is empty)

## Test plan

- [ ] CI green on this PR
- [ ] Merge to `main`
- [ ] Tag pushed, workflow runs to completion
- [ ] GH release exists at v0.15.2.13 with `hardpy-0.15.2.13-py3-none-any.whl` and `hardpy-0.15.2.13.tar.gz` attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)