### PR TITLE
NEX-1204: fix secondary-lang lookup + add settings popover arrow-nav (v0.15.2.14)

### DIFF
--- a/examples/i18n_demo/hardpy.toml
+++ b/examples/i18n_demo/hardpy.toml
@@ -21,3 +21,11 @@ secondary_display_language = "en"
 # Canonical language for the persisted/uploaded report (runstore + StandCloud).
 # Statestore keeps raw i18n: keys for live operator-panel translation.
 report_language = "en"
+
+[[test_configs]]
+name = "Mixed (default)"
+file = "pytest.ini"
+
+[[test_configs]]
+name = "All Pass"
+file = "pytest_pass.ini"

--- a/examples/i18n_demo/pytest_pass.ini
+++ b/examples/i18n_demo/pytest_pass.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --hardpy-pt
+          --hardpy-db-url http://dev:dev@localhost:5984/
+testpaths =
+python_files = test_2.py

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -344,6 +344,66 @@ function App(): JSX.Element {
     };
   }, [showSettingsMenu]);
 
+  // When the settings popover opens, focus its first item and let Up/Down
+  // cycle focus between MenuItems. Blueprint's Menu doesn't auto-focus or
+  // wire arrow-key navigation on its own — without this, an operator on the
+  // GPIO d-pad can open the cog menu (F2) but can't move the highlight.
+  // NEX-1204.
+  React.useEffect(() => {
+    if (!showSettingsMenu) {
+      return;
+    }
+    const getItems = (): HTMLElement[] =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '[role="menu"] [role="menuitem"]',
+        ),
+      );
+
+    const focusTimer = setTimeout(() => {
+      const items = getItems();
+      if (items.length > 0) {
+        items[0].focus();
+      }
+    }, 50);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "F2" || e.key === "Escape") {
+        e.preventDefault();
+        setShowSettingsMenu(false);
+        return;
+      }
+      const items = getItems();
+      if (items.length === 0) {
+        return;
+      }
+      const idx = items.indexOf(document.activeElement as HTMLElement);
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = idx < 0 ? 0 : (idx + 1) % items.length;
+        items[next].focus();
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        const prev = idx < 0 ? items.length - 1 : (idx - 1 + items.length) % items.length;
+        items[prev].focus();
+      } else if (e.key === "Enter" || e.key === " ") {
+        // Blueprint's MenuItem (anchor) responds to click but not space/enter
+        // when focused via JS; route both to a click so confirm-via-keyboard
+        // works for d-pad operators.
+        if (idx >= 0) {
+          e.preventDefault();
+          items[idx].click();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [showSettingsMenu]);
+
   /**
    * Renders the database content.
    * @returns {JSX.Element} The rendered content.

--- a/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
+++ b/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
@@ -104,7 +104,7 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
   suppressDuplicate = true,
   className,
 }) => {
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   const secondaryLang = useSecondaryLanguage();
 
   let parsed: Parsed;
@@ -128,7 +128,12 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
     if (!parsed.key) {
       return "";
     }
-    return t(parsed.key, { ...parsed.args, lng: lang, ns: effectiveNs });
+    // getFixedT binds to a specific language regardless of the active one;
+    // passing `lng` as an option to the hook's t() returns the literal key
+    // when the requested language isn't currently active, which printed
+    // "app.completion.pass" beneath the Chinese on midline-lab.
+    const langT = i18n.getFixedT(lang, effectiveNs);
+    return langT(parsed.key, parsed.args);
   };
 
   const primary = renderOne(i18n.language);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.15.2.13"
+    version = "0.15.2.14"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]


### PR DESCRIPTION
## Summary

Follow-up to PR #8. Two operator-UX regressions surfaced on midline-lab against v0.15.2.13 with `language="zh"` / `secondary_display_language="en"`:

- **Pass/Fail completion overlay rendered the literal key as the English secondary.** The Chinese primary (`通过` / `失败`) rendered correctly, but underneath we got `app.completion.pass` / `app.completion.fail` instead of `PASS` / `FAIL`. Root cause: `t(key, { lng, ns })` from the `useTranslation` hook returns the literal key when the requested `lng` isn't the currently-active language. Switched secondary rendering to `i18n.getFixedT(lang, ns)` which binds reliably regardless of the active language.
- **Settings cog popover had no arrow-key navigation.** F2 (or click) opens the popover, but Blueprint's `Menu` doesn't auto-focus or wire keyboard navigation on its own, so a d-pad operator couldn't move the highlight. Added a `useEffect` that focuses the first `[role="menuitem"]` on open and handles ArrowUp/Down (cycle), Enter/Space (click), F2/Escape (close).

Also adds an `All Pass` test_config to `examples/i18n_demo` so the green PASS overlay can be reached for smoke testing without editing test files.

Version bump: 0.15.2.13 → 0.15.2.14.

## Test plan

- [x] Local smoke: `examples/i18n_demo` with primary=zh / secondary=en, run All Pass config — green overlay shows `通过` / `PASS` stacked. Run Mixed config — red overlay shows `失败` / `FAIL` stacked.
- [x] Open cog popover with F2; ArrowDown/ArrowUp cycle focus; Enter activates; F2/Escape closes.
- [x] `yarn tsc --noEmit` — clean (4 pre-existing errors unrelated).
- [ ] Smoke on midline-lab once v0.15.2.14 is released and `hardpy-appliance` pin bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)