### PR TITLE
NEX-1206: route DialogBox text through i18n + dialog-render hardening

### DIFF
--- a/examples/i18n_demo/test_3_dialog.py
+++ b/examples/i18n_demo/test_3_dialog.py
@@ -1,0 +1,126 @@
+"""DialogBox i18n demo (NEX-1206 dialog gap).
+
+Exercises every operator-facing surface on ``run_dialog_box`` that previously
+shipped its raw ``i18n:`` key to the frontend instead of resolving it:
+
+- ``title_bar`` and ``dialog_text`` on the dialog itself
+- ``RadiobuttonWidget`` and ``CheckboxWidget`` field labels
+- ``MultistepWidget`` step titles and step bodies
+- ``{{var}}`` interpolation through the JSON-args suffix
+
+Run via the operator panel (``hardpy run``) — the panel renders primary
+(``zh`` per ``hardpy.toml``) stacked above secondary (``en``) for every
+field. Before the fix only the body of ``set_message`` / ``pytest.fail``
+strings rendered translated; the dialog title and widget labels surfaced
+the raw ``i18n:`` key.
+"""
+from hardpy import (
+    CheckboxWidget,
+    DialogBox,
+    MultistepWidget,
+    RadiobuttonWidget,
+    StepWidget,
+    TextInputWidget,
+    run_dialog_box,
+)
+import pytest
+
+
+pytestmark = pytest.mark.module_name("i18n:modules.module_dialog")
+
+
+@pytest.mark.case_name("i18n:tests.dialog_basic")
+def test_dialog_basic_translates_title_and_body():
+    """Plain confirm dialog — title and (multi-line) body resolve via i18n."""
+    confirmed = run_dialog_box(
+        DialogBox(
+            title_bar="i18n:dialog.confirm_visual.title",
+            dialog_text="i18n:dialog.confirm_visual.body",
+        ),
+    )
+    assert confirmed is True
+
+
+@pytest.mark.case_name("i18n:tests.dialog_text_input")
+def test_dialog_text_input_with_interpolation():
+    """Text-input dialog — title, body with ``{{prefix}}`` interpolation."""
+    serial = run_dialog_box(
+        DialogBox(
+            title_bar="i18n:dialog.scan_sn.title",
+            dialog_text='i18n:dialog.scan_sn.body{"prefix":"OVN-"}',
+            widget=TextInputWidget(),
+        ),
+    )
+    assert isinstance(serial, str)
+    assert serial != ""
+
+
+@pytest.mark.case_name("i18n:tests.dialog_radio")
+def test_dialog_radio_button_labels_translate():
+    """Radio fields carry ``i18n:`` keys — each option label resolves on the
+    operator panel; the value sent back to the test is the raw key string."""
+    chosen = run_dialog_box(
+        DialogBox(
+            title_bar="i18n:dialog.select_lane.title",
+            dialog_text="i18n:dialog.select_lane.body",
+            widget=RadiobuttonWidget(
+                fields=[
+                    "i18n:lane.left",
+                    "i18n:lane.center",
+                    "i18n:lane.right",
+                ],
+            ),
+        ),
+    )
+    # Server receives the raw key so downstream test code can route on it
+    # without depending on the operator's display language.
+    assert chosen in {"i18n:lane.left", "i18n:lane.center", "i18n:lane.right"}
+
+
+@pytest.mark.case_name("i18n:tests.dialog_checkbox")
+def test_dialog_checkbox_labels_translate():
+    """Checkbox fields carry ``i18n:`` keys — every label resolves; the
+    selected raw-key strings come back as a list."""
+    selected = run_dialog_box(
+        DialogBox(
+            title_bar="i18n:dialog.select_harnesses.title",
+            dialog_text="i18n:dialog.select_harnesses.body",
+            widget=CheckboxWidget(
+                fields=[
+                    "i18n:harness.power",
+                    "i18n:harness.sensor",
+                    "i18n:harness.comms",
+                ],
+            ),
+        ),
+    )
+    assert isinstance(selected, list)
+    assert all(item.startswith("i18n:harness.") for item in selected)
+
+
+@pytest.mark.case_name("i18n:tests.dialog_multistep")
+def test_dialog_multistep_step_titles_and_bodies_translate():
+    """Multistep tabs — each tab title and step body resolves on the panel."""
+    confirmed = run_dialog_box(
+        DialogBox(
+            title_bar="i18n:dialog.multistep_walkthrough.title",
+            dialog_text="i18n:dialog.confirm_visual.body",
+            widget=MultistepWidget(
+                steps=[
+                    StepWidget(
+                        title="i18n:step.power_on.title",
+                        text="i18n:step.power_on.body",
+                    ),
+                    StepWidget(
+                        title="i18n:step.connect_scanner.title",
+                        text="i18n:step.connect_scanner.body",
+                    ),
+                    StepWidget(
+                        title="i18n:step.final_check.title",
+                        text="i18n:step.final_check.body",
+                    ),
+                ],
+            ),
+        ),
+    )
+    assert confirmed is True

--- a/examples/i18n_demo/translations/common.json
+++ b/examples/i18n_demo/translations/common.json
@@ -9,15 +9,66 @@
       "printer_check": "Printer Check",
       "serial_check": "Serial Number Check",
       "cycle_check": "Cycle Counter Check",
-      "shutdown_check": "Shutdown Sequence"
+      "shutdown_check": "Shutdown Sequence",
+      "dialog_basic": "Dialog: confirm",
+      "dialog_text_input": "Dialog: serial-number scan",
+      "dialog_radio": "Dialog: select fixture lane",
+      "dialog_checkbox": "Dialog: select harnesses installed",
+      "dialog_multistep": "Dialog: multistep walkthrough"
     },
     "modules": {
       "module_basic": "Basic Demo",
-      "module_advanced": "Advanced Demo"
+      "module_advanced": "Advanced Demo",
+      "module_dialog": "Dialog Demo"
     },
     "info": {
       "ready": "Station ready",
       "cycle": "Running cycle {{n}} of {{total}}"
+    },
+    "dialog": {
+      "confirm_visual": {
+        "title": "Visual inspection",
+        "body": "Inspect the unit under test.\nConfirm there are no visible defects."
+      },
+      "scan_sn": {
+        "title": "Scan serial number",
+        "body": "Scan the unit's serial number with the handheld scanner.\nExpected prefix: {{prefix}}"
+      },
+      "select_lane": {
+        "title": "Select fixture lane",
+        "body": "Pick the lane this DUT is loaded on."
+      },
+      "select_harnesses": {
+        "title": "Select harnesses installed",
+        "body": "Check every harness currently routed through the fixture."
+      },
+      "multistep_walkthrough": {
+        "title": "Multistep walkthrough"
+      }
+    },
+    "lane": {
+      "left": "Left lane",
+      "right": "Right lane",
+      "center": "Center lane"
+    },
+    "harness": {
+      "power": "Power harness",
+      "sensor": "Sensor harness",
+      "comms": "Comms harness"
+    },
+    "step": {
+      "power_on": {
+        "title": "Power on",
+        "body": "Flip the bench supply to ON.\nWait for the green status LED."
+      },
+      "connect_scanner": {
+        "title": "Connect scanner",
+        "body": "Plug the barcode scanner into the fixture.\nWait for the audible chime."
+      },
+      "final_check": {
+        "title": "Final check",
+        "body": "Verify the DUT is seated correctly before confirming."
+      }
     }
   },
   "zh": {
@@ -30,15 +81,66 @@
       "printer_check": "打印机检查",
       "serial_check": "序列号检查",
       "cycle_check": "循环计数器检查",
-      "shutdown_check": "关机流程"
+      "shutdown_check": "关机流程",
+      "dialog_basic": "对话框: 确认",
+      "dialog_text_input": "对话框: 扫描序列号",
+      "dialog_radio": "对话框: 选择工位通道",
+      "dialog_checkbox": "对话框: 选择已安装的线束",
+      "dialog_multistep": "对话框: 多步骤演练"
     },
     "modules": {
       "module_basic": "基础演示",
-      "module_advanced": "高级演示"
+      "module_advanced": "高级演示",
+      "module_dialog": "对话框演示"
     },
     "info": {
       "ready": "工位就绪",
       "cycle": "正在运行第 {{n}} 个循环 (共 {{total}} 个)"
+    },
+    "dialog": {
+      "confirm_visual": {
+        "title": "外观检查",
+        "body": "请检查被测产品。\n确认无外观缺陷后继续。"
+      },
+      "scan_sn": {
+        "title": "扫描序列号",
+        "body": "请使用手持扫描枪扫描产品序列号。\n预期前缀: {{prefix}}"
+      },
+      "select_lane": {
+        "title": "选择工位通道",
+        "body": "请选择当前 DUT 所在的通道。"
+      },
+      "select_harnesses": {
+        "title": "选择已安装的线束",
+        "body": "请勾选当前工位上已连接的全部线束。"
+      },
+      "multistep_walkthrough": {
+        "title": "多步骤演练"
+      }
+    },
+    "lane": {
+      "left": "左侧通道",
+      "right": "右侧通道",
+      "center": "中间通道"
+    },
+    "harness": {
+      "power": "电源线束",
+      "sensor": "传感器线束",
+      "comms": "通信线束"
+    },
+    "step": {
+      "power_on": {
+        "title": "上电",
+        "body": "将台式电源打开至 ON。\n等待绿色状态指示灯亮起。"
+      },
+      "connect_scanner": {
+        "title": "连接扫描枪",
+        "body": "将条码扫描枪接入工位。\n等待提示音。"
+      },
+      "final_check": {
+        "title": "最终确认",
+        "body": "确认 DUT 已正确就位后再继续。"
+      }
     }
   },
   "th": {
@@ -51,15 +153,66 @@
       "printer_check": "ตรวจสอบเครื่องพิมพ์",
       "serial_check": "ตรวจสอบหมายเลขเครื่อง",
       "cycle_check": "ตรวจสอบตัวนับรอบ",
-      "shutdown_check": "ขั้นตอนการปิดเครื่อง"
+      "shutdown_check": "ขั้นตอนการปิดเครื่อง",
+      "dialog_basic": "กล่องโต้ตอบ: ยืนยัน",
+      "dialog_text_input": "กล่องโต้ตอบ: สแกนหมายเลขเครื่อง",
+      "dialog_radio": "กล่องโต้ตอบ: เลือกช่องของฟิกซ์เจอร์",
+      "dialog_checkbox": "กล่องโต้ตอบ: เลือกชุดสายไฟที่ติดตั้ง",
+      "dialog_multistep": "กล่องโต้ตอบ: ขั้นตอนหลายลำดับ"
     },
     "modules": {
       "module_basic": "การสาธิตพื้นฐาน",
-      "module_advanced": "การสาธิตขั้นสูง"
+      "module_advanced": "การสาธิตขั้นสูง",
+      "module_dialog": "การสาธิตกล่องโต้ตอบ"
     },
     "info": {
       "ready": "สถานีพร้อม",
       "cycle": "กำลังรันรอบที่ {{n}} จาก {{total}}"
+    },
+    "dialog": {
+      "confirm_visual": {
+        "title": "ตรวจสอบด้วยสายตา",
+        "body": "ตรวจสอบอุปกรณ์ที่ทดสอบ\nยืนยันว่าไม่มีตำหนิที่มองเห็นได้"
+      },
+      "scan_sn": {
+        "title": "สแกนหมายเลขเครื่อง",
+        "body": "สแกนหมายเลขเครื่องด้วยเครื่องสแกนแบบมือถือ\nคำนำหน้าที่คาดไว้: {{prefix}}"
+      },
+      "select_lane": {
+        "title": "เลือกช่องของฟิกซ์เจอร์",
+        "body": "เลือกช่องที่ DUT วางอยู่"
+      },
+      "select_harnesses": {
+        "title": "เลือกชุดสายไฟที่ติดตั้ง",
+        "body": "เลือกชุดสายไฟทุกชุดที่เดินผ่านฟิกซ์เจอร์"
+      },
+      "multistep_walkthrough": {
+        "title": "ขั้นตอนหลายลำดับ"
+      }
+    },
+    "lane": {
+      "left": "ช่องซ้าย",
+      "right": "ช่องขวา",
+      "center": "ช่องกลาง"
+    },
+    "harness": {
+      "power": "สายไฟ",
+      "sensor": "สายเซ็นเซอร์",
+      "comms": "สายสื่อสาร"
+    },
+    "step": {
+      "power_on": {
+        "title": "เปิดเครื่อง",
+        "body": "เปิดแหล่งจ่ายไฟไปที่ ON\nรอจนกว่าไฟแสดงสถานะจะเป็นสีเขียว"
+      },
+      "connect_scanner": {
+        "title": "เชื่อมต่อสแกนเนอร์",
+        "body": "เสียบเครื่องสแกนบาร์โค้ดเข้ากับฟิกซ์เจอร์\nรอสัญญาณเสียง"
+      },
+      "final_check": {
+        "title": "ตรวจสอบขั้นสุดท้าย",
+        "body": "ตรวจสอบให้แน่ใจว่า DUT วางถูกต้องก่อนยืนยัน"
+      }
     }
   }
 }

--- a/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
+++ b/hardpy/hardpy_panel/frontend/src/TranslatedText.tsx
@@ -62,6 +62,78 @@ export function parseI18nValue(value: string): Parsed {
   }
 }
 
+export interface ResolvedI18n {
+  primary: string;
+  /** Secondary-language render. ``null`` when no secondary lang is configured
+   * or when ``suppressDuplicate`` collapses an identical secondary. */
+  secondary: string | null;
+}
+
+interface ResolveOptions {
+  /** Static key used when no ``value`` is provided. Mirrors ``TranslatedText.tKey``. */
+  tKey?: string;
+  /** Interpolation args paired with ``tKey``. */
+  args?: Record<string, unknown>;
+  /** Namespace override. Defaults to ``tests`` for ``value`` calls,
+   * ``translation`` for ``tKey`` calls. */
+  ns?: string;
+  /** Suppress secondary when identical to primary. Default ``true``. */
+  suppressDuplicate?: boolean;
+}
+
+/**
+ * Resolve an operator-facing string to primary/secondary-language renders.
+ *
+ * Used by ``TranslatedText`` internally and by call sites that need plain
+ * strings (e.g. Blueprint ``Dialog`` title prop, text-width sizing math).
+ */
+export function useResolveI18nValue(
+  value: string | null | undefined,
+  options: ResolveOptions = {},
+): ResolvedI18n {
+  const { i18n } = useTranslation();
+  const secondaryLang = useSecondaryLanguage();
+  const { tKey, args, ns, suppressDuplicate = true } = options;
+
+  let parsed: Parsed;
+  let isDynamic = false;
+  if (value !== undefined && value !== null) {
+    parsed = parseI18nValue(value);
+    isDynamic = true;
+  } else if (tKey) {
+    parsed = { key: tKey, args };
+  } else {
+    return { primary: "", secondary: null };
+  }
+
+  const effectiveNs = ns ?? (isDynamic ? TESTS_NS : "translation");
+
+  const renderOne = (lang: string): string => {
+    if (parsed.literal !== undefined) {
+      return parsed.literal;
+    }
+    if (!parsed.key) {
+      return "";
+    }
+    // getFixedT binds to a specific language regardless of the active one;
+    // passing `lng` as an option to the hook's t() returns the literal key
+    // when the requested language isn't currently active, which printed
+    // "app.completion.pass" beneath the Chinese on midline-lab.
+    const langT = i18n.getFixedT(lang, effectiveNs);
+    return langT(parsed.key, parsed.args);
+  };
+
+  const primary = renderOne(i18n.language);
+  if (!secondaryLang || secondaryLang === i18n.language) {
+    return { primary, secondary: null };
+  }
+  const secondary = renderOne(secondaryLang);
+  if (suppressDuplicate && secondary === primary) {
+    return { primary, secondary: null };
+  }
+  return { primary, secondary };
+}
+
 interface TranslatedTextProps {
   /** Dynamic runtime string (may be ``i18n:`` prefixed or literal). */
   value?: string | null;
@@ -104,44 +176,14 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
   suppressDuplicate = true,
   className,
 }) => {
-  const { i18n } = useTranslation();
-  const secondaryLang = useSecondaryLanguage();
+  const { primary, secondary } = useResolveI18nValue(value, {
+    tKey,
+    args,
+    ns,
+    suppressDuplicate,
+  });
 
-  let parsed: Parsed;
-  let isDynamic = false;
-  if (value !== undefined && value !== null) {
-    parsed = parseI18nValue(value);
-    isDynamic = true;
-  } else if (tKey) {
-    parsed = { key: tKey, args };
-  } else {
-    return null;
-  }
-
-  const defaultNs = isDynamic ? TESTS_NS : "translation";
-  const effectiveNs = ns ?? defaultNs;
-
-  const renderOne = (lang: string): string => {
-    if (parsed.literal !== undefined) {
-      return parsed.literal;
-    }
-    if (!parsed.key) {
-      return "";
-    }
-    // getFixedT binds to a specific language regardless of the active one;
-    // passing `lng` as an option to the hook's t() returns the literal key
-    // when the requested language isn't currently active, which printed
-    // "app.completion.pass" beneath the Chinese on midline-lab.
-    const langT = i18n.getFixedT(lang, effectiveNs);
-    return langT(parsed.key, parsed.args);
-  };
-
-  const primary = renderOne(i18n.language);
-  const shouldShowSecondary = secondaryLang && secondaryLang !== i18n.language;
-  const secondary = shouldShowSecondary ? renderOne(secondaryLang) : null;
-  const displaySecondary = secondary !== null && (!suppressDuplicate || secondary !== primary);
-
-  if (!primary && !displaySecondary) {
+  if (!primary && secondary === null) {
     return null;
   }
 
@@ -160,7 +202,7 @@ export const TranslatedText: React.FC<TranslatedTextProps> = ({
       }}
     >
       <span style={primaryStyle}>{primary}</span>
-      {displaySecondary && (
+      {secondary !== null && (
         <span style={{ ...defaultSecondaryStyle, ...secondaryStyle }}>{secondary}</span>
       )}
     </span>

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -26,6 +26,50 @@ import {
   calculateDialogDimensions,
 } from "./DialogUtils";
 import { useTranslation } from "react-i18next";
+import { TranslatedText, useResolveI18nValue } from "../TranslatedText";
+
+/**
+ * Render a multi-line, possibly ``i18n:``-prefixed value as a stack of <p>
+ * elements (one per line of the resolved primary string). When a secondary
+ * language is configured, its lines are stacked below with the standard
+ * lighter/smaller treatment.
+ *
+ * Used for ``dialog_text`` and Multistep ``step.info.text`` — both are
+ * authored as free-form prose with embedded newlines, and both flow through
+ * the same i18n catalog as ``set_message`` / ``pytest.fail`` text.
+ */
+const MultilineTranslated: React.FC<{
+  value: string;
+  pStyle?: React.CSSProperties;
+}> = ({ value, pStyle }) => {
+  const { primary, secondary } = useResolveI18nValue(value);
+  if (!primary && secondary === null) {
+    return null;
+  }
+  const secondaryStyle: React.CSSProperties = {
+    ...pStyle,
+    opacity: 0.85,
+    fontSize: "0.75em",
+  };
+  return (
+    <>
+      {primary.split("\n").map((line, i) => (
+        // Lines are stable within a render; index-as-key is appropriate here
+        // (duplicate lines were producing duplicate keys with the previous
+        // `key={line.trim()}` pattern).
+        <p key={`p-${i}`} style={pStyle}>
+          {line}
+        </p>
+      ))}
+      {secondary !== null &&
+        secondary.split("\n").map((line, i) => (
+          <p key={`s-${i}`} style={secondaryStyle}>
+            {line}
+          </p>
+        ))}
+    </>
+  );
+};
 
 const HEX_BASE = 16;
 const screenWidth = window.screen.width;
@@ -174,7 +218,7 @@ const RadioButtonComponent = ({
     {fields?.map((option: string) => (
       <Radio
         key={option}
-        label={option}
+        label={<TranslatedText value={option} inline noDefaultSecondaryStyle />}
         checked={selectedRadioButton === option}
         onChange={() => setSelectedRadioButton(option)}
         onKeyDown={handleKeyDown}
@@ -207,7 +251,7 @@ const CheckboxComponent = ({
     {fields?.map((option: string) => (
       <Checkbox
         key={option}
-        label={option}
+        label={<TranslatedText value={option} inline noDefaultSecondaryStyle />}
         checked={selectedCheckboxes.includes(option)}
         autoFocus={option === fields[0]}
         onKeyDown={handleKeyDown}
@@ -395,18 +439,29 @@ const renderMultistep = (
   <Tabs id={props.title_bar}>
     {props.widget_info?.steps?.map((step: Step) => (
       <Tab
+        // Tab `id` is a DOM id and `key` is a React reconciliation key — both
+        // stay as the raw value so they remain stable across language toggles.
+        // The visible `title` is routed through TranslatedText so i18n keys
+        // resolve to operator-facing prose.
         id={step.info?.title}
         key={step.info?.title}
-        title={step.info?.title}
+        title={
+          <TranslatedText
+            value={step.info?.title}
+            inline
+            noDefaultSecondaryStyle
+          />
+        }
         style={{ fontSize: `${props.font_size}px` }}
         panel={
           <div className="step-container">
             <div className="step-content">
-              {step.info?.text?.split("\n").map((line) => (
-                <p key={line} style={{ textAlign: "left" }}>
-                  {line}
-                </p>
-              ))}
+              {step.info?.text && (
+                <MultilineTranslated
+                  value={step.info.text}
+                  pStyle={{ textAlign: "left" }}
+                />
+              )}
               {step.info.image && (
                 <img
                   src={`data:image/image;base64,${step.info.image?.base64}`}
@@ -485,6 +540,11 @@ const renderMultistep = (
  */
 export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
   const { t, i18n } = useTranslation();
+  // Resolve operator-facing strings up front. ``primary`` feeds layout math
+  // (text-width sizing) so the dialog opens at the correct size for the
+  // localized prose; ``TranslatedText`` is used in the JSX so secondary
+  // language stacking matches the rest of the operator panel.
+  const resolvedDialogText = useResolveI18nValue(props.dialog_text);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [inputText, setInputText] = useState("");
   const [selectedRadioButton, setSelectedRadioButton] = useState("");
@@ -787,7 +847,7 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
   );
 
   const textHeight =
-    (calculateTextLines(props.dialog_text, dialogWidthForText) ?? 1) *
+    (calculateTextLines(resolvedDialogText.primary, dialogWidthForText) ?? 1) *
     lineHeight;
   const step = props.widget_info?.steps?.[0];
   const textStepHeight = step?.info?.text
@@ -875,7 +935,13 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
 
   return (
     <Dialog
-      title={props.title_bar}
+      title={
+        <TranslatedText
+          value={props.title_bar}
+          inline
+          noDefaultSecondaryStyle
+        />
+      }
       icon="info-sign"
       isOpen={dialogOpen}
       onClose={props.pass_fail ? undefined : handleClose}
@@ -904,11 +970,15 @@ export function StartConfirmationDialog(props: Readonly<Props>): JSX.Element {
           padding: "10px",
         }}
       >
-        {props.dialog_text.split("\n").map((line) => (
-          <p key={line.trim()} style={{ textAlign: "left" }}>
-            {line}
-          </p>
-        ))}
+        <MultilineTranslated
+          value={props.dialog_text}
+          pStyle={{ textAlign: "left" }}
+        />
+        {/* First-letter keyboard shortcut still matches the RAW field value,
+            so a fixture using ``i18n:radio.option_a`` keys would have all
+            options share the same "i" prefix and the shortcut would not
+            distinguish them. Fixtures wanting first-letter shortcuts should
+            keep plain-string field labels for now — tracked as a follow-up. */}
         {widgetType === WidgetType.TextInput &&
           renderTextInput(props, inputText, setInputText, handleKeyDown, t)}
         {widgetType === WidgetType.NumericInput &&

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
@@ -615,44 +615,48 @@ export class TestSuite extends React.Component<Props, State> {
     rowIndex: number
   ): React.ReactElement {
     const test = test_topics[rowIndex];
+    // Cases that have not yet reached run_dialog_box arrive without a
+    // dialog_box field; the row renderer still needs to render the status
+    // chip, so guard every access rather than crashing the whole panel.
+    const dialog_box = test.dialog_box;
     const { info: widget_info, type: widget_type } =
-      test.dialog_box.widget || {};
+      dialog_box?.widget || {};
     const {
       base64: image_base64,
       width: image_width,
       border: image_border,
-    } = test.dialog_box.image || {};
+    } = dialog_box?.image || {};
 
     return this.commonCellRender(
       <div style={{ marginTop: "0.2em", marginBottom: "0.2em" }}>
-        {test.dialog_box.dialog_text &&
+        {dialog_box?.dialog_text &&
           test.status === "run" &&
           this.props.commonTestRunStatus === "run" &&
-          test.dialog_box.visible && (
+          dialog_box.visible && (
             <StartConfirmationDialog
-              title_bar={test.dialog_box.title_bar ?? test.name}
-              dialog_text={test.dialog_box.dialog_text}
+              title_bar={dialog_box.title_bar ?? test.name}
+              dialog_text={dialog_box.dialog_text}
               widget_info={widget_info}
               widget_type={widget_type}
               image_base64={image_base64}
               image_width={image_width}
               image_border={image_border}
-              is_visible={test.dialog_box.visible}
-              id={test.dialog_box.id}
-              font_size={test.dialog_box.font_size}
+              is_visible={dialog_box.visible}
+              id={dialog_box.id}
+              font_size={dialog_box.font_size}
               html_code={
-                test.dialog_box.html?.is_raw_html
-                  ? test.dialog_box.html?.code_or_url
+                dialog_box.html?.is_raw_html
+                  ? dialog_box.html?.code_or_url
                   : undefined
               }
               html_url={
-                !test.dialog_box.html?.is_raw_html
-                  ? test.dialog_box.html?.code_or_url
+                !dialog_box.html?.is_raw_html
+                  ? dialog_box.html?.code_or_url
                   : undefined
               }
-              html_width={test.dialog_box.html?.width}
-              html_border={test.dialog_box.html?.border}
-              pass_fail={test.dialog_box.pass_fail}
+              html_width={dialog_box.html?.width}
+              html_border={dialog_box.html?.border}
+              pass_fail={dialog_box.pass_fail}
             />
           )}
         <TestStatus

--- a/hardpy/hardpy_panel/frontend/src/i18n.tsx
+++ b/hardpy/hardpy_panel/frontend/src/i18n.tsx
@@ -87,10 +87,23 @@ const initializeI18n = async () => {
       },
     });
 
+  // i18next's `preload` schedules loads but does NOT block init(). On slower
+  // devices (or when the kiosk hits the backend before it's fully ready), the
+  // secondary language can stay unloaded — getFixedT then returns the literal
+  // key (e.g. "app.completion.fail"). Explicitly load each preload lang here
+  // so the i18n store is guaranteed populated before the React app renders.
+  for (const lang of preload) {
+    try {
+      await i18n.loadLanguages(lang);
+    } catch (e) {
+      console.error(`Failed to load i18n language ${lang}:`, e);
+    }
+  }
+
   await loadTestsNamespace();
   console.log("i18n initialized with:", i18n.language, "secondary:", secondaryLang);
 };
 
-initializeI18n();
+export const i18nReady = initializeI18n();
 
 export default i18n;

--- a/hardpy/hardpy_panel/frontend/src/index.tsx
+++ b/hardpy/hardpy_panel/frontend/src/index.tsx
@@ -12,7 +12,7 @@ import { Provider } from "use-pouchdb";
 import "normalize.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
-import './i18n';
+import { i18nReady } from './i18n';
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
@@ -49,6 +49,7 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 
+await i18nReady;
 const syncURL = await getSyncURL();
 if (syncURL !== undefined) {
   const db = new PouchDB(syncURL);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.15.2.14"
+    version = "0.15.2.15"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]


### PR DESCRIPTION
## Summary

- Routes `DialogBox` title / body / widget option labels / multistep step titles + bodies through the same i18n catalog renderer (`TranslatedText` + new `useResolveI18nValue` hook) that already handles `set_message`, `pytest.fail`, case names, and the completion overlay.
- Fixes a pre-existing crash in `TestSuite.cellRendererStatus` that blew up reading `.widget` on cases without a `dialog_box` field (every fresh-DB case before its first `run_dialog_box` call). Guarded with optional chaining; bundled here rather than split into its own ticket to keep the release surface narrow.
- Closes the i18n preload race: `i18next.init`'s `preload` is non-blocking, so on slower kiosks the secondary language could be unloaded when React mounted and `getFixedT` returned the literal key. Now `await loadLanguages` for every preload language inside the init promise, export as `i18nReady`, top-level-await it in `index.tsx` before `root.render`.
- Bumps `0.15.2.14 -> 0.15.2.15`.
- Extends `examples/i18n_demo/` with `test_3_dialog.py` covering every dialog surface (base, text input + `{{var}}` interpolation, radio, checkbox, multistep) plus matching `dialog.*` / `lane.*` / `harness.*` / `step.*` entries in `translations/common.json` (en / zh / th).

## Test plan

- [x] Stand up dev hardpy build (vite :3000 + uvicorn :8000) against the i18n_demo fixture with `frontend.language = "zh"` + `secondary_display_language = "en"`
- [x] Manual: run `test_3_dialog.py` end-to-end on the panel — confirm title bar, dialog body, radio/checkbox labels, multistep tabs + step bodies all render primary + secondary stacked
- [x] Manual: confirm existing operator-panel paths (`set_message`, `pytest.fail`, case names, completion overlay) still resolve correctly after the `TranslatedText` refactor (single source of truth via `useResolveI18nValue`)
- [x] Manual: verify the panel no longer crashes on first paint when CouchDB has fresh test rows without `dialog_box` populated
- [ ] Verify against the endline branch on hardpy-appliance (`feature/NEX-1059-endline-i18n`) before bumping the pin in hardpy-appliance PR #58

## Notes

First-letter keyboard shortcut on Radio/Checkbox keeps matching raw field strings — a fixture using `i18n:` keys on every option breaks the shortcut as a known limitation; documented inline in `DialogBox.tsx`.

Tab `id` / `key` and `widget_info.fields` in the server payload keep raw `i18n:` keys so DOM ids stay stable across language toggles and downstream test code can route on the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)